### PR TITLE
Use CodeInternal when user-supplied Codecs can't marshal Status

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -378,7 +378,6 @@ func TestMarshalStatusError(t *testing.T) {
 
 	assertInternalError := func(tb testing.TB, opts ...connect.ClientOption) {
 		tb.Helper()
-		tb.Skip("TODO: error is just Unknown: EOF")
 		client, err := pingv1connect.NewPingServiceClient(server.Client(), server.URL, opts...)
 		assert.Nil(tb, err)
 		req := connect.NewRequest(&pingv1.FailRequest{Code: int32(connect.CodeResourceExhausted)})

--- a/protocol_grpc_handler_stream.go
+++ b/protocol_grpc_handler_stream.go
@@ -102,9 +102,7 @@ func (hs *handlerSender) Close(err error) error {
 	// mutate the trailers map that the user sees.
 	mergedTrailers := make(http.Header, len(hs.trailer)+2) // always make space for status & message
 	mergeHeaders(mergedTrailers, hs.trailer)
-	if marshalErr := grpcErrorToTrailer(hs.bufferPool, mergedTrailers, hs.protobuf, err); marshalErr != nil {
-		return marshalErr
-	}
+	grpcErrorToTrailer(hs.bufferPool, mergedTrailers, hs.protobuf, err)
 	if hs.web && !hs.wroteToBody {
 		// We're using gRPC-Web and we haven't yet written to the body. Since we're
 		// not sending any response messages, the gRPC specification calls this a

--- a/protocol_grpc_util.go
+++ b/protocol_grpc_util.go
@@ -146,7 +146,7 @@ func statusFromError(err error) (*statusv1.Status, error) {
 			anyProtoDetail, err := anypb.New(detail)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"can't create an *anypb.Any from %v (type %T): %v",
+					"can't create an *anypb.Any from %v (type %T): %w",
 					detail, detail, err,
 				)
 			}


### PR DESCRIPTION
Fixes #197.