### PR TITLE
Do not return error from Client constructor

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -48,14 +48,13 @@ func BenchmarkConnect(b *testing.B) {
 	assert.True(b, ok)
 	httpTransport.DisableCompression = true
 
-	client, err := pingv1connect.NewPingServiceClient(
+	client := pingv1connect.NewPingServiceClient(
 		httpClient,
 		server.URL,
 		connect.WithGRPC(),
 		connect.WithGzip(),
 		connect.WithGzipRequests(),
 	)
-	assert.Nil(b, err)
 	twoMiB := strings.Repeat("a", 2*1024*1024)
 	b.ResetTimer()
 

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -59,15 +59,11 @@ func Example_client() {
 	// client that communicate over in-memory pipes. Don't do this in production!
 	httpClient = examplePingServer.Client()
 
-	client, err := pingv1connect.NewPingServiceClient(
+	client := pingv1connect.NewPingServiceClient(
 		httpClient,
 		examplePingServer.URL(),
 		connect.WithGRPC(),
 	)
-	if err != nil {
-		logger.Println("error:", err)
-		return
-	}
 	res, err := client.Ping(
 		context.Background(),
 		connect.NewRequest(&pingv1.PingRequest{Number: 42}),

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -133,7 +133,7 @@ func generatePreamble(g *protogen.GeneratedFile, file *protogen.File) {
 	g.P()
 	wrapComments(g, "This is a compile-time assertion to ensure that this generated file ",
 		"and the connect package are compatible. If you get a compiler error that this constant ",
-		"isn't defined, this code was generated with a version of connect newer than the one ",
+		"is not defined, this code was generated with a version of connect newer than the one ",
 		"compiled into your binary. You can fix the problem by either regenerating this code ",
 		"with an older version of connect or updating the connect version compiled into your binary.")
 	g.P("const _ = ", connectPackage.Ident("IsAtLeastVersion0_0_1"))
@@ -199,10 +199,11 @@ func generateClientImplementation(g *protogen.GeneratedFile, service *protogen.S
 		deprecated(g)
 	}
 	g.P("func ", names.ClientConstructor, " (httpClient ", connectPackage.Ident("HTTPClient"),
-		", baseURL string, opts ...", clientOption, ") (", names.Client, ", error) {")
+		", baseURL string, opts ...", clientOption, ") ", names.Client, " {")
 	g.P("baseURL = ", stringsPackage.Ident("TrimRight"), `(baseURL, "/")`)
+	g.P("return &", names.ClientImpl, "{")
 	for _, method := range service.Methods {
-		g.P(unexport(method.GoName), "Client, err := ",
+		g.P(unexport(method.GoName), ": ",
 			connectPackage.Ident("NewClient"),
 			"[", method.Input.GoIdent, ", ", method.Output.GoIdent, "]",
 			"(",
@@ -210,16 +211,9 @@ func generateClientImplementation(g *protogen.GeneratedFile, service *protogen.S
 		g.P("httpClient,")
 		g.P(`baseURL + "`, procedureName(method), `",`)
 		g.P("opts...,")
-		g.P(")")
-		g.P("if err != nil {")
-		g.P("return nil, err")
-		g.P("}")
+		g.P("),")
 	}
-	g.P("return &", names.ClientImpl, "{")
-	for _, method := range service.Methods {
-		g.P(unexport(method.GoName), ": ", unexport(method.GoName), "Client,")
-	}
-	g.P("}, nil")
+	g.P("}")
 	g.P("}")
 	g.P()
 
@@ -359,11 +353,11 @@ func generateUnimplementedServerImplementation(g *protogen.GeneratedFile, servic
 		if method.Desc.IsStreamingServer() || method.Desc.IsStreamingClient() {
 			g.P("return ", connectPackage.Ident("NewError"), "(",
 				connectPackage.Ident("CodeUnimplemented"), ", ", errorsPackage.Ident("New"),
-				`("`, method.Desc.FullName(), ` isn't implemented"))`)
+				`("`, method.Desc.FullName(), ` is not implemented"))`)
 		} else {
 			g.P("return nil, ", connectPackage.Ident("NewError"), "(",
 				connectPackage.Ident("CodeUnimplemented"), ", ", errorsPackage.Ident("New"),
-				`("`, method.Desc.FullName(), ` isn't implemented"))`)
+				`("`, method.Desc.FullName(), ` is not implemented"))`)
 		}
 		g.P("}")
 		g.P()

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -277,8 +277,7 @@ func TestServer(t *testing.T) {
 	testMatrix := func(t *testing.T, server *httptest.Server, bidi bool) { // nolint:thelper
 		run := func(t *testing.T, opts ...connect.ClientOption) {
 			t.Helper()
-			client, err := pingv1connect.NewPingServiceClient(server.Client(), server.URL, opts...)
-			assert.Nil(t, err)
+			client := pingv1connect.NewPingServiceClient(server.Client(), server.URL, opts...)
 			testPing(t, client)
 			testSum(t, client)
 			testCountUp(t, client)
@@ -354,8 +353,7 @@ func TestHeaderBasic(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	client, err := pingv1connect.NewPingServiceClient(server.Client(), server.URL, connect.WithGRPC())
-	assert.Nil(t, err)
+	client := pingv1connect.NewPingServiceClient(server.Client(), server.URL, connect.WithGRPC())
 	req := connect.NewRequest(&pingv1.PingRequest{})
 	req.Header().Set(key, cval)
 	res, err := client.Ping(context.Background(), req)
@@ -378,10 +376,9 @@ func TestMarshalStatusError(t *testing.T) {
 
 	assertInternalError := func(tb testing.TB, opts ...connect.ClientOption) {
 		tb.Helper()
-		client, err := pingv1connect.NewPingServiceClient(server.Client(), server.URL, opts...)
-		assert.Nil(tb, err)
+		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL, opts...)
 		req := connect.NewRequest(&pingv1.FailRequest{Code: int32(connect.CodeResourceExhausted)})
-		_, err = client.Fail(context.Background(), req)
+		_, err := client.Fail(context.Background(), req)
 		tb.Log(err)
 		assert.NotNil(t, err)
 		var connectErr *connect.Error
@@ -406,16 +403,15 @@ func TestBidiRequiresHTTP2(t *testing.T) {
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
-	client, err := pingv1connect.NewPingServiceClient(
+	client := pingv1connect.NewPingServiceClient(
 		server.Client(),
 		server.URL,
 		connect.WithGRPC(),
 	)
-	assert.Nil(t, err)
 	stream := client.CumSum(context.Background())
 	assert.Nil(t, stream.Send(&pingv1.CumSumRequest{}))
 	assert.Nil(t, stream.CloseSend())
-	_, err = stream.Receive()
+	_, err := stream.Receive()
 	assert.NotNil(t, err)
 	var connectErr *connect.Error
 	assert.True(t, errors.As(err, &connectErr))

--- a/interceptor_example_test.go
+++ b/interceptor_example_test.go
@@ -41,16 +41,12 @@ func ExampleInterceptor() {
 			})
 		},
 	)
-	client, err := pingv1connect.NewPingServiceClient(
+	client := pingv1connect.NewPingServiceClient(
 		examplePingServer.Client(),
 		examplePingServer.URL(),
 		connect.WithGRPC(),
 		connect.WithInterceptors(loggingInterceptor),
 	)
-	if err != nil {
-		logger.Println("error:", err)
-		return
-	}
 	if _, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{Number: 42})); err != nil {
 		logger.Println("error:", err)
 		return
@@ -84,16 +80,12 @@ func ExampleWithInterceptors() {
 			})
 		},
 	)
-	client, err := pingv1connect.NewPingServiceClient(
+	client := pingv1connect.NewPingServiceClient(
 		examplePingServer.Client(),
 		examplePingServer.URL(),
 		connect.WithGRPC(),
 		connect.WithInterceptors(outer, inner),
 	)
-	if err != nil {
-		logger.Println("error:", err)
-		return
-	}
 	if _, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{})); err != nil {
 		logger.Println("error:", err)
 		return

--- a/internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go
@@ -28,10 +28,10 @@ import (
 )
 
 // This is a compile-time assertion to ensure that this generated file and the connect package are
-// compatible. If you get a compiler error that this constant isn't defined, this code was generated
-// with a version of connect newer than the one compiled into your binary. You can fix the problem
-// by either regenerating this code with an older version of connect or updating the connect version
-// compiled into your binary.
+// compatible. If you get a compiler error that this constant is not defined, this code was
+// generated with a version of connect newer than the one compiled into your binary. You can fix the
+// problem by either regenerating this code with an older version of connect or updating the connect
+// version compiled into your binary.
 const _ = connect_go.IsAtLeastVersion0_0_1
 
 const (
@@ -60,55 +60,35 @@ type PingServiceClient interface {
 //
 // The URL supplied here should be the base URL for the gRPC server (for example,
 // http://api.acme.com or https://acme.com/grpc).
-func NewPingServiceClient(httpClient connect_go.HTTPClient, baseURL string, opts ...connect_go.ClientOption) (PingServiceClient, error) {
+func NewPingServiceClient(httpClient connect_go.HTTPClient, baseURL string, opts ...connect_go.ClientOption) PingServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
-	pingClient, err := connect_go.NewClient[v1.PingRequest, v1.PingResponse](
-		httpClient,
-		baseURL+"/connect.ping.v1.PingService/Ping",
-		opts...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	failClient, err := connect_go.NewClient[v1.FailRequest, v1.FailResponse](
-		httpClient,
-		baseURL+"/connect.ping.v1.PingService/Fail",
-		opts...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	sumClient, err := connect_go.NewClient[v1.SumRequest, v1.SumResponse](
-		httpClient,
-		baseURL+"/connect.ping.v1.PingService/Sum",
-		opts...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	countUpClient, err := connect_go.NewClient[v1.CountUpRequest, v1.CountUpResponse](
-		httpClient,
-		baseURL+"/connect.ping.v1.PingService/CountUp",
-		opts...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	cumSumClient, err := connect_go.NewClient[v1.CumSumRequest, v1.CumSumResponse](
-		httpClient,
-		baseURL+"/connect.ping.v1.PingService/CumSum",
-		opts...,
-	)
-	if err != nil {
-		return nil, err
-	}
 	return &pingServiceClient{
-		ping:    pingClient,
-		fail:    failClient,
-		sum:     sumClient,
-		countUp: countUpClient,
-		cumSum:  cumSumClient,
-	}, nil
+		ping: connect_go.NewClient[v1.PingRequest, v1.PingResponse](
+			httpClient,
+			baseURL+"/connect.ping.v1.PingService/Ping",
+			opts...,
+		),
+		fail: connect_go.NewClient[v1.FailRequest, v1.FailResponse](
+			httpClient,
+			baseURL+"/connect.ping.v1.PingService/Fail",
+			opts...,
+		),
+		sum: connect_go.NewClient[v1.SumRequest, v1.SumResponse](
+			httpClient,
+			baseURL+"/connect.ping.v1.PingService/Sum",
+			opts...,
+		),
+		countUp: connect_go.NewClient[v1.CountUpRequest, v1.CountUpResponse](
+			httpClient,
+			baseURL+"/connect.ping.v1.PingService/CountUp",
+			opts...,
+		),
+		cumSum: connect_go.NewClient[v1.CumSumRequest, v1.CumSumResponse](
+			httpClient,
+			baseURL+"/connect.ping.v1.PingService/CumSum",
+			opts...,
+		),
+	}
 }
 
 // pingServiceClient implements PingServiceClient.
@@ -198,21 +178,21 @@ func NewPingServiceHandler(svc PingServiceHandler, opts ...connect_go.HandlerOpt
 type UnimplementedPingServiceHandler struct{}
 
 func (UnimplementedPingServiceHandler) Ping(context.Context, *connect_go.Request[v1.PingRequest]) (*connect_go.Response[v1.PingResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Ping isn't implemented"))
+	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Ping is not implemented"))
 }
 
 func (UnimplementedPingServiceHandler) Fail(context.Context, *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Fail isn't implemented"))
+	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Fail is not implemented"))
 }
 
 func (UnimplementedPingServiceHandler) Sum(context.Context, *connect_go.ClientStream[v1.SumRequest, v1.SumResponse]) error {
-	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum isn't implemented"))
+	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum is not implemented"))
 }
 
 func (UnimplementedPingServiceHandler) CountUp(context.Context, *connect_go.Request[v1.CountUpRequest], *connect_go.ServerStream[v1.CountUpResponse]) error {
-	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CountUp isn't implemented"))
+	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CountUp is not implemented"))
 }
 
 func (UnimplementedPingServiceHandler) CumSum(context.Context, *connect_go.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error {
-	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CumSum isn't implemented"))
+	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CumSum is not implemented"))
 }


### PR DESCRIPTION
Per discussion. While returning an error from `NewClient` does make a lot of sense to do some preflight validation, it's painful to use in a lot of cases, and we can just effectively do the validation before the first call. All errors that come up in practice are things you find within seconds of using the `Client` for the first time, and you fix once, and never hit again. On balance, this seems like a good tradeoff.

I am not in love with the propagation of the `err` field.