### PR TITLE
Cleanup

### DIFF
--- a/client_example_test.go
+++ b/client_example_test.go
@@ -64,7 +64,7 @@ func Example_client() {
 		examplePingServer.URL(),
 		connect.WithGRPC(),
 	)
-	res, err := client.Ping(
+	response, err := client.Ping(
 		context.Background(),
 		connect.NewRequest(&pingv1.PingRequest{Number: 42}),
 	)
@@ -72,8 +72,8 @@ func Example_client() {
 		logger.Println("error:", err)
 		return
 	}
-	logger.Println("response content-type:", res.Header().Get("Content-Type"))
-	logger.Println("response message:", res.Msg)
+	logger.Println("response content-type:", response.Header().Get("Content-Type"))
+	logger.Println("response message:", response.Msg)
 
 	// Output:
 	// response content-type: application/grpc+proto

--- a/client_stream.go
+++ b/client_stream.go
@@ -43,11 +43,11 @@ func (c *ClientStreamForClient[Req, Res]) RequestHeader() http.Header {
 // If the server returns an error, Send returns an error that wraps io.EOF.
 // Clients should check for case using the standard library's errors.Is and
 // unmarshal the error using CloseAndReceive.
-func (c *ClientStreamForClient[Req, Res]) Send(msg *Req) error {
+func (c *ClientStreamForClient[Req, Res]) Send(request *Req) error {
 	if c.err != nil {
 		return c.err
 	}
-	return c.sender.Send(msg)
+	return c.sender.Send(request)
 }
 
 // CloseAndReceive closes the send side of the stream and waits for the
@@ -59,7 +59,7 @@ func (c *ClientStreamForClient[Req, Res]) CloseAndReceive() (*Response[Res], err
 	if err := c.sender.Close(nil); err != nil {
 		return nil, err
 	}
-	res, err := receiveUnaryResponse[Res](c.receiver)
+	response, err := receiveUnaryResponse[Res](c.receiver)
 	if err != nil {
 		_ = c.receiver.Close()
 		return nil, err
@@ -67,7 +67,7 @@ func (c *ClientStreamForClient[Req, Res]) CloseAndReceive() (*Response[Res], err
 	if err := c.receiver.Close(); err != nil {
 		return nil, err
 	}
-	return res, nil
+	return response, nil
 }
 
 // ServerStreamForClient is the client's view of a server streaming RPC.
@@ -169,11 +169,11 @@ func (b *BidiStreamForClient[Req, Res]) Receive() (*Res, error) {
 	if b.err != nil {
 		return nil, b.err
 	}
-	var res Res
-	if err := b.receiver.Receive(&res); err != nil {
+	var msg Res
+	if err := b.receiver.Receive(&msg); err != nil {
 		return nil, err
 	}
-	return &res, nil
+	return &msg, nil
 }
 
 // CloseReceive closes the receive side of the stream.

--- a/compression.go
+++ b/compression.go
@@ -123,19 +123,19 @@ type readOnlyCompressionPools interface {
 	CommaSeparatedNames() string
 }
 
-func newReadOnlyCompressionPools(pools map[string]*compressionPool) readOnlyCompressionPools {
-	known := make([]string, 0, len(pools))
-	for name := range pools {
-		known = append(known, name)
+func newReadOnlyCompressionPools(nameToPool map[string]*compressionPool) readOnlyCompressionPools {
+	knownNames := make([]string, 0, len(nameToPool))
+	for name := range nameToPool {
+		knownNames = append(knownNames, name)
 	}
 	return &namedCompressionPools{
-		nameToPools:         pools,
-		commaSeparatedNames: strings.Join(known, ","),
+		nameToPool:          nameToPool,
+		commaSeparatedNames: strings.Join(knownNames, ","),
 	}
 }
 
 type namedCompressionPools struct {
-	nameToPools         map[string]*compressionPool
+	nameToPool          map[string]*compressionPool
 	commaSeparatedNames string
 }
 
@@ -143,11 +143,11 @@ func (m *namedCompressionPools) Get(name string) *compressionPool {
 	if name == "" || name == compressionIdentity {
 		return nil
 	}
-	return m.nameToPools[name]
+	return m.nameToPool[name]
 }
 
 func (m *namedCompressionPools) Contains(name string) bool {
-	_, ok := m.nameToPools[name]
+	_, ok := m.nameToPool[name]
 	return ok
 }
 

--- a/handler_example_test.go
+++ b/handler_example_test.go
@@ -33,12 +33,14 @@ type ExamplePingServer struct {
 // Ping implements pingv1connect.PingServiceHandler.
 func (*ExamplePingServer) Ping(
 	_ context.Context,
-	req *connect.Request[pingv1.PingRequest],
+	request *connect.Request[pingv1.PingRequest],
 ) (*connect.Response[pingv1.PingResponse], error) {
-	return connect.NewResponse(&pingv1.PingResponse{
-		Number: req.Msg.Number,
-		Text:   req.Msg.Text,
-	}), nil
+	return connect.NewResponse(
+		&pingv1.PingResponse{
+			Number: request.Msg.Number,
+			Text:   request.Msg.Text,
+		},
+	), nil
 }
 
 func Example_handler() {
@@ -50,9 +52,11 @@ func Example_handler() {
 	// Handlers, so they're compatible with most Go HTTP routers and middleware
 	// (for example, net/http's StripPrefix).
 	mux := http.NewServeMux()
-	mux.Handle(pingv1connect.NewPingServiceHandler(
-		&ExamplePingServer{}, // our business logic
-	))
+	mux.Handle(
+		pingv1connect.NewPingServiceHandler(
+			&ExamplePingServer{}, // our business logic
+		),
+	)
 	// You can serve gRPC's health and server reflection APIs using
 	// github.com/bufbuild/connect-grpchealth-go and github.com/bufbuild/connect-grpcreflect-go.
 
@@ -64,7 +68,7 @@ func Example_handler() {
 	//
 	// If you're not familiar with the many timeouts exposed by net/http, start with
 	// https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/.
-	srv := &http.Server{
+	server := &http.Server{
 		Addr:           ":http",
 		Handler:        mux,
 		ReadTimeout:    2500 * time.Millisecond,
@@ -73,5 +77,5 @@ func Example_handler() {
 	}
 	// You could also use golang.org/x/net/http2/h2c to serve gRPC requests
 	// without TLS.
-	_ = srv.ListenAndServeTLS("internal/testdata/server.crt", "internal/testdata/server.key")
+	_ = server.ListenAndServeTLS("internal/testdata/server.crt", "internal/testdata/server.key")
 }

--- a/interceptor_example_test.go
+++ b/interceptor_example_test.go
@@ -28,16 +28,16 @@ func ExampleInterceptor() {
 	logger := log.New(os.Stdout, "" /* prefix */, 0 /* flags */)
 	loggingInterceptor := connect.UnaryInterceptorFunc(
 		func(next connect.UnaryFunc) connect.UnaryFunc {
-			return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-				logger.Println("calling:", req.Spec().Procedure)
-				logger.Println("request:", req.Any())
-				res, err := next(ctx, req)
+			return connect.UnaryFunc(func(ctx context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
+				logger.Println("calling:", request.Spec().Procedure)
+				logger.Println("request:", request.Any())
+				response, err := next(ctx, request)
 				if err != nil {
 					logger.Println("error:", err)
 				} else {
-					logger.Println("response:", res.Any())
+					logger.Println("response:", response.Any())
 				}
-				return res, err
+				return response, err
 			})
 		},
 	)

--- a/option.go
+++ b/option.go
@@ -24,7 +24,7 @@ import (
 // In addition to any options grouped in the documentation below, remember that
 // Options are also valid ClientOptions.
 type ClientOption interface {
-	applyToClient(*clientConfiguration)
+	applyToClient(*clientConfig)
 }
 
 // WithClientOptions composes multiple ClientOptions into one.
@@ -67,7 +67,7 @@ func WithRequestCompression(name string) ClientOption {
 // In addition to any options grouped in the documentation below, remember that
 // all Options are also HandlerOptions.
 type HandlerOption interface {
-	applyToHandler(*handlerConfiguration)
+	applyToHandler(*handlerConfig)
 }
 
 // WithHandlerOptions composes multiple HandlerOptions into one.
@@ -235,7 +235,7 @@ type clientOptionsOption struct {
 	options []ClientOption
 }
 
-func (o *clientOptionsOption) applyToClient(config *clientConfiguration) {
+func (o *clientOptionsOption) applyToClient(config *clientConfig) {
 	for _, option := range o.options {
 		option.applyToClient(config)
 	}
@@ -245,14 +245,14 @@ type codecOption struct {
 	Codec Codec
 }
 
-func (o *codecOption) applyToClient(config *clientConfiguration) {
+func (o *codecOption) applyToClient(config *clientConfig) {
 	if o.Codec == nil || o.Codec.Name() == "" {
 		return
 	}
 	config.Codec = o.Codec
 }
 
-func (o *codecOption) applyToHandler(config *handlerConfiguration) {
+func (o *codecOption) applyToHandler(config *handlerConfig) {
 	if o.Codec == nil || o.Codec.Name() == "" {
 		return
 	}
@@ -264,11 +264,11 @@ type compressionOption struct {
 	CompressionPool *compressionPool
 }
 
-func (o *compressionOption) applyToClient(config *clientConfiguration) {
+func (o *compressionOption) applyToClient(config *clientConfig) {
 	o.apply(config.CompressionPools)
 }
 
-func (o *compressionOption) applyToHandler(config *handlerConfiguration) {
+func (o *compressionOption) applyToHandler(config *handlerConfig) {
 	o.apply(config.CompressionPools)
 }
 
@@ -283,11 +283,11 @@ type compressMinBytesOption struct {
 	Min int
 }
 
-func (o *compressMinBytesOption) applyToClient(config *clientConfiguration) {
+func (o *compressMinBytesOption) applyToClient(config *clientConfig) {
 	config.CompressMinBytes = o.Min
 }
 
-func (o *compressMinBytesOption) applyToHandler(config *handlerConfiguration) {
+func (o *compressMinBytesOption) applyToHandler(config *handlerConfig) {
 	config.CompressMinBytes = o.Min
 }
 
@@ -295,7 +295,7 @@ type handlerOptionsOption struct {
 	options []HandlerOption
 }
 
-func (o *handlerOptionsOption) applyToHandler(config *handlerConfiguration) {
+func (o *handlerOptionsOption) applyToHandler(config *handlerConfig) {
 	for _, option := range o.options {
 		option.applyToHandler(config)
 	}
@@ -305,7 +305,7 @@ type grpcOption struct {
 	web bool
 }
 
-func (o *grpcOption) applyToClient(config *clientConfiguration) {
+func (o *grpcOption) applyToClient(config *clientConfig) {
 	config.Protocol = &protocolGRPC{web: o.web}
 }
 
@@ -313,11 +313,11 @@ type interceptorsOption struct {
 	Interceptors []Interceptor
 }
 
-func (o *interceptorsOption) applyToClient(config *clientConfiguration) {
+func (o *interceptorsOption) applyToClient(config *clientConfig) {
 	config.Interceptor = o.chainWith(config.Interceptor)
 }
 
-func (o *interceptorsOption) applyToHandler(config *handlerConfiguration) {
+func (o *interceptorsOption) applyToHandler(config *handlerConfig) {
 	config.Interceptor = o.chainWith(config.Interceptor)
 }
 
@@ -338,13 +338,13 @@ type optionsOption struct {
 	options []Option
 }
 
-func (o *optionsOption) applyToClient(config *clientConfiguration) {
+func (o *optionsOption) applyToClient(config *clientConfig) {
 	for _, option := range o.options {
 		option.applyToClient(config)
 	}
 }
 
-func (o *optionsOption) applyToHandler(config *handlerConfiguration) {
+func (o *optionsOption) applyToHandler(config *handlerConfig) {
 	for _, option := range o.options {
 		option.applyToHandler(config)
 	}
@@ -354,6 +354,6 @@ type requestCompressionOption struct {
 	Name string
 }
 
-func (o *requestCompressionOption) applyToClient(config *clientConfiguration) {
+func (o *requestCompressionOption) applyToClient(config *clientConfig) {
 	config.RequestCompressionName = o.Name
 }

--- a/protobuf_util.go
+++ b/protobuf_util.go
@@ -18,11 +18,11 @@ import (
 	"strings"
 )
 
-// extractProtobufPath returns the trailing portion of the URL's path,
+// extractProtoPath returns the trailing portion of the URL's path,
 // corresponding to the Protobuf package, service, and method. It always starts
 // with a slash. Within connect, we use this as (1) Specification.Procedure and
 // (2) the path when mounting handlers on muxes.
-func extractProtobufPath(url string) string {
+func extractProtoPath(url string) string {
 	segments := strings.Split(url, "/")
 	var pkg, method string
 	if len(segments) > 0 {

--- a/protobuf_util_test.go
+++ b/protobuf_util_test.go
@@ -22,40 +22,40 @@ import (
 
 func TestParseProtobufURL(t *testing.T) {
 	t.Parallel()
-	assertExtractedProtobufPath(
+	assertExtractedProtoPath(
 		t,
 		// full URL
 		"https://api.foo.com/grpc/foo.user.v1.UserService/GetUser",
 		"/foo.user.v1.UserService/GetUser",
 	)
-	assertExtractedProtobufPath(
+	assertExtractedProtoPath(
 		t,
 		// rooted path
 		"/foo.user.v1.UserService/GetUser",
 		"/foo.user.v1.UserService/GetUser",
 	)
-	assertExtractedProtobufPath(
+	assertExtractedProtoPath(
 		t,
 		// path without leading or trailing slashes
 		"foo.user.v1.UserService/GetUser",
 		"/foo.user.v1.UserService/GetUser",
 	)
-	assertExtractedProtobufPath(
+	assertExtractedProtoPath(
 		t,
 		// path with trailing slash
 		"/foo.user.v1.UserService.GetUser/",
 		"/foo.user.v1.UserService.GetUser",
 	)
 	// edge cases
-	assertExtractedProtobufPath(t, "", "/")
-	assertExtractedProtobufPath(t, "//", "/")
+	assertExtractedProtoPath(t, "", "/")
+	assertExtractedProtoPath(t, "//", "/")
 }
 
-func assertExtractedProtobufPath(tb testing.TB, inputURL, expectPath string) {
+func assertExtractedProtoPath(tb testing.TB, inputURL, expectPath string) {
 	tb.Helper()
 	assert.Equal(
 		tb,
-		extractProtobufPath(inputURL),
+		extractProtoPath(inputURL),
 		expectPath,
 	)
 }


### PR DESCRIPTION
Mostly variable renames, a few newlines on parameters, and renaming `extractProtobufPath` to `extractProtoPath` to match with our `proto` naming elsewhere. Also `Configuration -> Config`, which I think is fine and a standard we've used.