### PR TITLE
Fix server-side timeout handling

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -373,7 +373,6 @@ func TestHeaderBasic(t *testing.T) {
 }
 
 func TestTimeoutParsing(t *testing.T) {
-	t.Skip("TODO: timeouts aren't propagated into user code")
 	t.Parallel()
 	const timeout = 10 * time.Minute
 	pingServer := &pluggablePingServer{

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/bufbuild/connect-go"
 	"github.com/bufbuild/connect-go/internal/assert"
@@ -369,6 +370,32 @@ func TestHeaderBasic(t *testing.T) {
 	response, err := client.Ping(context.Background(), request)
 	assert.Nil(t, err)
 	assert.Equal(t, response.Header().Get(key), hval)
+}
+
+func TestTimeoutParsing(t *testing.T) {
+	t.Skip("TODO: timeouts aren't propagated into user code")
+	t.Parallel()
+	const timeout = 10 * time.Minute
+	pingServer := &pluggablePingServer{
+		ping: func(ctx context.Context, request *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
+			deadline, ok := ctx.Deadline()
+			assert.True(t, ok)
+			remaining := time.Until(deadline)
+			assert.True(t, remaining > 0)
+			assert.True(t, remaining <= timeout)
+			return connect.NewResponse(&pingv1.PingResponse{}), nil
+		},
+	}
+	mux := http.NewServeMux()
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	client := pingv1connect.NewPingServiceClient(server.Client(), server.URL, connect.WithGRPC())
+	_, err := client.Ping(ctx, connect.NewRequest(&pingv1.PingRequest{}))
+	assert.Nil(t, err)
 }
 
 func TestMarshalStatusError(t *testing.T) {

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -59,7 +59,17 @@ func TestServer(t *testing.T) {
 			assert.Equal(t, response.Header().Get(handlerHeader), headerValue)
 			assert.Equal(t, response.Trailer().Get(handlerTrailer), trailerValue)
 		})
-		t.Run("large ping", func(t *testing.T) {
+		t.Run("zero_ping", func(t *testing.T) {
+			request := connect.NewRequest(&pingv1.PingRequest{})
+			request.Header().Set(clientHeader, headerValue)
+			response, err := client.Ping(context.Background(), request)
+			assert.Nil(t, err)
+			var expect pingv1.PingResponse
+			assert.Equal(t, response.Msg, &expect)
+			assert.Equal(t, response.Header().Get(handlerHeader), headerValue)
+			assert.Equal(t, response.Trailer().Get(handlerTrailer), trailerValue)
+		})
+		t.Run("large_ping", func(t *testing.T) {
 			// Using a large payload splits the request and response over multiple
 			// packets, ensuring that we're managing HTTP readers and writers
 			// correctly.

--- a/header.go
+++ b/header.go
@@ -117,16 +117,6 @@ func percentDecodeSlow(bufferPool *bufferPool, encoded string, offset int) strin
 	return out.String()
 }
 
-// addCommaSeparatedHeader is a helper to produce headers like
-// {"Allow": "GET, POST"}.
-func addCommaSeparatedHeader(header http.Header, key, value string) {
-	if prev := header.Get(key); prev != "" {
-		header.Set(key, prev+", "+value)
-	} else {
-		header.Set(key, value)
-	}
-}
-
 func mergeHeaders(into, from http.Header) {
 	for k, vals := range from {
 		into[k] = append(into[k], vals...)

--- a/protocol.go
+++ b/protocol.go
@@ -159,20 +159,15 @@ func (r *errorTranslatingReceiver) Close() error {
 }
 
 func sortedAcceptPostValue(handlers []protocolHandler) string {
-	var max int
-	for _, handler := range handlers {
-		max += len(handler.ContentTypes())
-	}
-	seen := make(map[string]struct{}, max)
-	accept := make([]string, 0, max)
+	contentTypes := make(map[string]struct{})
 	for _, handler := range handlers {
 		for contentType := range handler.ContentTypes() {
-			if _, ok := seen[contentType]; ok {
-				continue
-			}
-			seen[contentType] = struct{}{}
-			accept = append(accept, contentType)
+			contentTypes[contentType] = struct{}{}
 		}
+	}
+	accept := make([]string, 0, len(contentTypes))
+	for ct := range contentTypes {
+		accept = append(accept, ct)
 	}
 	sort.Strings(accept)
 	return strings.Join(accept, ", ")

--- a/protocol.go
+++ b/protocol.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 )
 
+const discardLimit = 1024 * 1024 * 4 // 4MiB
+
 // A Protocol defines the HTTP semantics to use when sending and receiving
 // messages. It ties together codecs, compressors, and net/http to produce
 // Senders and Receivers.
@@ -183,8 +185,8 @@ func discard(reader io.Reader) error {
 		return err
 	}
 	// We don't want to get stuck throwing data away forever, so limit how much
-	// we're willing to do here: at most, we'll copy 4 MiB.
-	lr := &io.LimitedReader{R: reader, N: 1024 * 1024 * 4}
+	// we're willing to do here.
+	lr := &io.LimitedReader{R: reader, N: discardLimit}
 	_, err := io.Copy(io.Discard, lr)
 	return err
 }

--- a/protocol_grpc_util.go
+++ b/protocol_grpc_util.go
@@ -16,7 +16,6 @@ package connect
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"runtime"
 	"strconv"
@@ -43,25 +42,6 @@ const (
 //   User-Agent → "grpc-" Language ?("-" Variant) "/" Version ?( " ("  *(AdditionalProperty ";") ")" )
 func userAgent() string {
 	return fmt.Sprintf("grpc-go-connect/%s (%s)", Version, runtime.Version())
-}
-
-func isCommaOrSpace(c rune) bool {
-	return c == ',' || c == ' '
-}
-
-func acceptPostValue(web bool, codecs readOnlyCodecs) string {
-	bare, prefix := typeDefaultGRPC, typeDefaultGRPCPrefix
-	if web {
-		bare, prefix = typeWebGRPC, typeWebGRPCPrefix
-	}
-	names := codecs.Names()
-	for i, name := range names {
-		names[i] = prefix + name
-	}
-	if codecs.Get(codecNameProto) != nil {
-		names = append(names, bare)
-	}
-	return strings.Join(names, ",")
 }
 
 func codecFromContentType(web bool, contentType string) string {
@@ -157,16 +137,4 @@ func statusFromError(err error) (*statusv1.Status, error) {
 		}
 	}
 	return status, nil
-}
-
-func discard(reader io.Reader) error {
-	if lr, ok := reader.(*io.LimitedReader); ok {
-		_, err := io.Copy(io.Discard, lr)
-		return err
-	}
-	// We don't want to get stuck throwing data away forever, so limit how much
-	// we're willing to do here: at most, we'll copy 4 MiB.
-	lr := &io.LimitedReader{R: reader, N: 1024 * 1024 * 4}
-	_, err := io.Copy(io.Discard, lr)
-	return err
 }


### PR DESCRIPTION
Now that we've defined the Connect protocol, we can simplify the protocol
interfaces: content-type negotiation is simpler, so the interface gets smaller.
This is also an easy moment to fix a bug in server-side timeout handling.
