### PR TITLE
Return an Unavailable error on failed requests

### DIFF
--- a/protocol_grpc_client_stream.go
+++ b/protocol_grpc_client_stream.go
@@ -276,7 +276,7 @@ func (cs *duplexClientStream) makeRequest(prepared chan struct{}) {
 	// establish the receive side of the stream.
 	response, err := cs.httpClient.Do(request)
 	if err != nil {
-		cs.setResponseError(err)
+		cs.setResponseError(NewError(CodeUnavailable, err))
 		return
 	}
 


### PR DESCRIPTION
This returns a more intuitive `Unavailable` error when issuing a request to an unreachable host.  