### PR TITLE
Leverage embedding more

### DIFF
--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -425,7 +425,7 @@ func (r *connectStreamingClientReceiver) validateResponse(response *http.Respons
 			r.compressionPools.CommaSeparatedNames(),
 		)
 	}
-	r.unmarshaler.envelopeReader.compressionPool = r.compressionPools.Get(compression)
+	r.unmarshaler.compressionPool = r.compressionPools.Get(compression)
 	mergeHeaders(r.header, response.Header)
 	return nil
 }


### PR DESCRIPTION
Unmarshalers embed `envelopeReader`, so we can use shorter-form field
access.
