### PR TITLE
Export AsError

### DIFF
--- a/code.go
+++ b/code.go
@@ -261,7 +261,7 @@ func (c *Code) UnmarshalText(data []byte) error {
 // CodeOf returns the error's status code if it is or wraps a *connect.Error
 // and CodeUnknown otherwise.
 func CodeOf(err error) Code {
-	if connectErr, ok := asError(err); ok {
+	if connectErr, ok := AsError(err); ok {
 		return connectErr.Code()
 	}
 	return CodeUnknown

--- a/envelope.go
+++ b/envelope.go
@@ -93,7 +93,7 @@ func (w *envelopeWriter) write(env *envelope) *Error {
 	prefix[0] = env.Flags
 	binary.BigEndian.PutUint32(prefix[1:5], uint32(env.Data.Len()))
 	if _, err := w.writer.Write(prefix[:]); err != nil {
-		if connectErr, ok := asError(err); ok {
+		if connectErr, ok := AsError(err); ok {
 			return connectErr
 		}
 		return errorf(CodeUnknown, "write envelope: %w", err)
@@ -190,7 +190,7 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 		return NewError(CodeUnknown, err)
 	case err != nil || prefixBytesRead < 5:
 		// Something else has gone wrong - the stream didn't end cleanly.
-		if connectErr, ok := asError(err); ok {
+		if connectErr, ok := AsError(err); ok {
 			return connectErr
 		}
 		return errorf(

--- a/error.go
+++ b/error.go
@@ -70,6 +70,13 @@ func NewError(c Code, underlying error) *Error {
 	return &Error{code: c, err: underlying}
 }
 
+// AsError uses errors.As to unwrap any error and look for an *Error.
+func AsError(err error) (*Error, bool) {
+	var connectErr *Error
+	ok := errors.As(err, &connectErr)
+	return connectErr, ok
+}
+
 func (e *Error) Error() string {
 	message := e.Message()
 	if message == "" {
@@ -157,13 +164,6 @@ func errorf(c Code, template string, args ...any) *Error {
 	return NewError(c, fmt.Errorf(template, args...))
 }
 
-// asError uses errors.As to unwrap any error and look for a connect *Error.
-func asError(err error) (*Error, bool) {
-	var connectErr *Error
-	ok := errors.As(err, &connectErr)
-	return connectErr, ok
-}
-
 // wrapIfUncoded ensures that all errors are wrapped. It leaves already-wrapped
 // errors unchanged, uses wrapIfContextError to apply codes to context.Canceled
 // and context.DeadlineExceeded, and falls back to wrapping other errors with
@@ -173,7 +173,7 @@ func wrapIfUncoded(err error) error {
 		return nil
 	}
 	maybeCodedErr := wrapIfContextError(err)
-	if _, ok := asError(maybeCodedErr); ok {
+	if _, ok := AsError(maybeCodedErr); ok {
 		return maybeCodedErr
 	}
 	return NewError(CodeUnknown, maybeCodedErr)
@@ -183,7 +183,7 @@ func wrapIfUncoded(err error) error {
 // context.Canceled and context.DeadlineExceeded errors, but only if they
 // haven't already been wrapped.
 func wrapIfContextError(err error) error {
-	if _, ok := asError(err); ok {
+	if _, ok := AsError(err); ok {
 		return err
 	}
 	if errors.Is(err, context.Canceled) {

--- a/error_test.go
+++ b/error_test.go
@@ -61,7 +61,7 @@ func TestErrorCode(t *testing.T) {
 		"another: %w",
 		NewError(CodeUnavailable, errors.New("foo")),
 	)
-	connectErr, ok := asError(err)
+	connectErr, ok := AsError(err)
 	assert.True(t, ok)
 	assert.Equal(t, connectErr.Code(), CodeUnavailable)
 }

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -884,7 +884,7 @@ func grpcErrorToTrailer(bufferPool *bufferPool, trailer http.Header, protobuf Co
 		)
 		return
 	}
-	if connectErr, ok := asError(err); ok {
+	if connectErr, ok := AsError(err); ok {
 		mergeHeaders(trailer, connectErr.meta)
 	}
 	trailer.Set(grpcHeaderStatus, code)
@@ -897,7 +897,7 @@ func grpcStatusFromError(err error) (*statusv1.Status, error) {
 		Code:    int32(CodeUnknown),
 		Message: err.Error(),
 	}
-	if connectErr, ok := asError(err); ok {
+	if connectErr, ok := AsError(err); ok {
 		status.Code = int32(connectErr.Code())
 		status.Message = connectErr.Message()
 		details, err := connectErr.detailsAsAny()


### PR DESCRIPTION
As @mfridman and @smaye81 use Connect more and more, they're feeling the
lack of this function. It's a very small API, but a noticeable quality
of life improvement when working with custom error types.

Fixes TCN-86