### PR TITLE
Rename compression options, unexport defaults

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -52,8 +52,7 @@ func BenchmarkConnect(b *testing.B) {
 		httpClient,
 		server.URL,
 		connect.WithGRPC(),
-		connect.WithGzip(),
-		connect.WithGzipRequests(),
+		connect.WithSendGzip(),
 	)
 	twoMiB := strings.Repeat("a", 2*1024*1024)
 	b.ResetTimer()

--- a/client.go
+++ b/client.go
@@ -186,8 +186,8 @@ func newClientConfig(url string, options []ClientOption) (*clientConfig, *Error)
 		CompressionPools: make(map[string]*compressionPool),
 		BufferPool:       newBufferPool(),
 	}
-	WithProtoBinaryCodec().applyToClient(&config)
-	WithGzip().applyToClient(&config)
+	withProtoBinaryCodec().applyToClient(&config)
+	withGzip().applyToClient(&config)
 	for _, opt := range options {
 		opt.applyToClient(&config)
 	}

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -300,13 +300,13 @@ func TestServer(t *testing.T) {
 				run(t)
 			})
 			t.Run("proto_gzip", func(t *testing.T) {
-				run(t, connect.WithGzipRequests())
+				run(t, connect.WithSendGzip())
 			})
 			t.Run("json_gzip", func(t *testing.T) {
 				run(
 					t,
-					connect.WithProtoJSONCodec(),
-					connect.WithGzipRequests(),
+					connect.WithProtoJSON(),
+					connect.WithSendGzip(),
 				)
 			})
 		})
@@ -315,14 +315,14 @@ func TestServer(t *testing.T) {
 				run(t, connect.WithGRPC())
 			})
 			t.Run("proto_gzip", func(t *testing.T) {
-				run(t, connect.WithGRPC(), connect.WithGzipRequests())
+				run(t, connect.WithGRPC(), connect.WithSendGzip())
 			})
 			t.Run("json_gzip", func(t *testing.T) {
 				run(
 					t,
 					connect.WithGRPC(),
-					connect.WithProtoJSONCodec(),
-					connect.WithGzipRequests(),
+					connect.WithProtoJSON(),
+					connect.WithSendGzip(),
 				)
 			})
 		})
@@ -331,14 +331,14 @@ func TestServer(t *testing.T) {
 				run(t, connect.WithGRPCWeb())
 			})
 			t.Run("proto_gzip", func(t *testing.T) {
-				run(t, connect.WithGRPCWeb(), connect.WithGzipRequests())
+				run(t, connect.WithGRPCWeb(), connect.WithSendGzip())
 			})
 			t.Run("json_gzip", func(t *testing.T) {
 				run(
 					t,
 					connect.WithGRPCWeb(),
-					connect.WithProtoJSONCodec(),
-					connect.WithGzipRequests(),
+					connect.WithProtoJSON(),
+					connect.WithSendGzip(),
 				)
 			})
 		})

--- a/handler.go
+++ b/handler.go
@@ -265,9 +265,9 @@ func newHandlerConfig(procedure string, options []HandlerOption) *handlerConfig 
 		HandleGRPCWeb:    true,
 		BufferPool:       newBufferPool(),
 	}
-	WithProtoBinaryCodec().applyToHandler(&config)
-	WithProtoJSONCodec().applyToHandler(&config)
-	WithGzip().applyToHandler(&config)
+	withProtoBinaryCodec().applyToHandler(&config)
+	withProtoJSONCodec().applyToHandler(&config)
+	withGzip().applyToHandler(&config)
 	for _, opt := range options {
 		opt.applyToHandler(&config)
 	}


### PR DESCRIPTION
Now that we're applying the default handler and client configuration in
the main connect package (vs passing options from the generated code),
we don't need to export `WithGzip` or `WithProtoBinaryCodec`.

After a lot of discussion, we've also decided to rename the compression
options. I've kept `WithCompression`, but made it a `HandlerOption`. For
clients, we now have `WithAcceptCompression` and `WithSendCompression`.

Since handlers accept JSON by default, I've made `WithProtoJSONCodec` a
`ClientOption` and shortened it slightly to `WithProtoJSON`. (We don't
do `WithGRPCProtocol` or `WithSendGzipCompression`, so this seems more
consistent too.)

Overall, this reduces the number of exported options and IMO makes the
naming more straightforward.

Fixes TCN-65