### PR TITLE
Rename client stream types

### DIFF
--- a/client.go
+++ b/client.go
@@ -115,16 +115,16 @@ func (c *Client[Req, Res]) CallUnary(ctx context.Context, request *Request[Req])
 }
 
 // CallClientStream calls a client streaming procedure.
-func (c *Client[Req, Res]) CallClientStream(ctx context.Context) *ClientStreamForClient[Req, Res] {
+func (c *Client[Req, Res]) CallClientStream(ctx context.Context) *ClientClientStream[Req, Res] {
 	if c.err != nil {
-		return &ClientStreamForClient[Req, Res]{err: c.err}
+		return &ClientClientStream[Req, Res]{err: c.err}
 	}
 	sender, receiver := c.newStream(ctx, StreamTypeClient)
-	return &ClientStreamForClient[Req, Res]{sender: sender, receiver: receiver}
+	return &ClientClientStream[Req, Res]{sender: sender, receiver: receiver}
 }
 
 // CallServerStream calls a server streaming procedure.
-func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Request[Req]) (*ServerStreamForClient[Res], error) {
+func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Request[Req]) (*ClientServerStream[Res], error) {
 	if c.err != nil {
 		return nil, c.err
 	}
@@ -141,16 +141,16 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 	if err := sender.Close(nil); err != nil {
 		return nil, err
 	}
-	return &ServerStreamForClient[Res]{receiver: receiver}, nil
+	return &ClientServerStream[Res]{receiver: receiver}, nil
 }
 
 // CallBidiStream calls a bidirectional streaming procedure.
-func (c *Client[Req, Res]) CallBidiStream(ctx context.Context) *BidiStreamForClient[Req, Res] {
+func (c *Client[Req, Res]) CallBidiStream(ctx context.Context) *ClientBidiStream[Req, Res] {
 	if c.err != nil {
-		return &BidiStreamForClient[Req, Res]{err: c.err}
+		return &ClientBidiStream[Req, Res]{err: c.err}
 	}
 	sender, receiver := c.newStream(ctx, StreamTypeBidi)
-	return &BidiStreamForClient[Req, Res]{sender: sender, receiver: receiver}
+	return &ClientBidiStream[Req, Res]{sender: sender, receiver: receiver}
 }
 
 func (c *Client[Req, Res]) newStream(ctx context.Context, streamType StreamType) (Sender, Receiver) {

--- a/client_stream.go
+++ b/client_stream.go
@@ -20,11 +20,11 @@ import (
 	"net/http"
 )
 
-// ClientStreamForClient is the client's view of a client streaming RPC.
+// ClientClientStream is the client's view of a client streaming RPC.
 //
 // It's returned from Client.CallClientStream, but doesn't currently have an
 // exported constructor function.
-type ClientStreamForClient[Req, Res any] struct {
+type ClientClientStream[Req, Res any] struct {
 	sender   Sender
 	receiver Receiver
 	// Error from client construction. If non-nil, return for all calls.
@@ -33,7 +33,7 @@ type ClientStreamForClient[Req, Res any] struct {
 
 // RequestHeader returns the request headers. Headers are sent to the server with the
 // first call to Send.
-func (c *ClientStreamForClient[Req, Res]) RequestHeader() http.Header {
+func (c *ClientClientStream[Req, Res]) RequestHeader() http.Header {
 	return c.sender.Header()
 }
 
@@ -43,7 +43,7 @@ func (c *ClientStreamForClient[Req, Res]) RequestHeader() http.Header {
 // If the server returns an error, Send returns an error that wraps io.EOF.
 // Clients should check for case using the standard library's errors.Is and
 // unmarshal the error using CloseAndReceive.
-func (c *ClientStreamForClient[Req, Res]) Send(request *Req) error {
+func (c *ClientClientStream[Req, Res]) Send(request *Req) error {
 	if c.err != nil {
 		return c.err
 	}
@@ -52,7 +52,7 @@ func (c *ClientStreamForClient[Req, Res]) Send(request *Req) error {
 
 // CloseAndReceive closes the send side of the stream and waits for the
 // response.
-func (c *ClientStreamForClient[Req, Res]) CloseAndReceive() (*Response[Res], error) {
+func (c *ClientClientStream[Req, Res]) CloseAndReceive() (*Response[Res], error) {
 	if c.err != nil {
 		return nil, c.err
 	}
@@ -70,11 +70,11 @@ func (c *ClientStreamForClient[Req, Res]) CloseAndReceive() (*Response[Res], err
 	return response, nil
 }
 
-// ServerStreamForClient is the client's view of a server streaming RPC.
+// ClientServerStream is the client's view of a server streaming RPC.
 //
 // It's returned from Client.CallServerStream, but doesn't currently have an
 // exported constructor function.
-type ServerStreamForClient[Res any] struct {
+type ClientServerStream[Res any] struct {
 	receiver Receiver
 	msg      Res
 	err      error
@@ -85,7 +85,7 @@ type ServerStreamForClient[Res any] struct {
 // either by reaching the end or by encountering an unexpected error. After
 // Receive returns false, the Err method will return any unexpected error
 // encountered.
-func (s *ServerStreamForClient[Res]) Receive() bool {
+func (s *ClientServerStream[Res]) Receive() bool {
 	if s.err != nil {
 		return false
 	}
@@ -96,12 +96,12 @@ func (s *ServerStreamForClient[Res]) Receive() bool {
 // Msg returns the most recent message unmarshaled by a call to Receive. The
 // returned message points to data that will be overwritten by the next call to
 // Receive.
-func (s *ServerStreamForClient[Res]) Msg() *Res {
+func (s *ClientServerStream[Res]) Msg() *Res {
 	return &s.msg
 }
 
 // Err returns the first non-EOF error that was encountered by Receive.
-func (s *ServerStreamForClient[Res]) Err() error {
+func (s *ClientServerStream[Res]) Err() error {
 	if s.err == nil || errors.Is(s.err, io.EOF) {
 		return nil
 	}
@@ -110,13 +110,13 @@ func (s *ServerStreamForClient[Res]) Err() error {
 
 // ResponseHeader returns the headers received from the server. It blocks until
 // the first call to Receive returns.
-func (s *ServerStreamForClient[Res]) ResponseHeader() http.Header {
+func (s *ClientServerStream[Res]) ResponseHeader() http.Header {
 	return s.receiver.Header()
 }
 
 // ResponseTrailer returns the trailers received from the server. Trailers
 // aren't fully populated until Receive() returns an error wrapping io.EOF.
-func (s *ServerStreamForClient[Res]) ResponseTrailer() http.Header {
+func (s *ClientServerStream[Res]) ResponseTrailer() http.Header {
 	if trailer, ok := s.receiver.Trailer(); ok {
 		return trailer
 	}
@@ -124,15 +124,15 @@ func (s *ServerStreamForClient[Res]) ResponseTrailer() http.Header {
 }
 
 // Close the receive side of the stream.
-func (s *ServerStreamForClient[Res]) Close() error {
+func (s *ClientServerStream[Res]) Close() error {
 	return s.receiver.Close()
 }
 
-// BidiStreamForClient is the client's view of a bidirectional streaming RPC.
+// ClientBidiStream is the client's view of a bidirectional streaming RPC.
 //
 // It's returned from Client.CallBidiStream, but doesn't currently have an
 // exported constructor function.
-type BidiStreamForClient[Req, Res any] struct {
+type ClientBidiStream[Req, Res any] struct {
 	sender   Sender
 	receiver Receiver
 	// Error from client construction. If non-nil, return for all calls.
@@ -141,7 +141,7 @@ type BidiStreamForClient[Req, Res any] struct {
 
 // RequestHeader returns the request headers. Headers are sent with the first
 // call to Send.
-func (b *BidiStreamForClient[Req, Res]) RequestHeader() http.Header {
+func (b *ClientBidiStream[Req, Res]) RequestHeader() http.Header {
 	return b.sender.Header()
 }
 
@@ -151,7 +151,7 @@ func (b *BidiStreamForClient[Req, Res]) RequestHeader() http.Header {
 // If the server returns an error, Send returns an error that wraps io.EOF.
 // Clients should check for case using the standard library's errors.Is and
 // unmarshal the error using Receive.
-func (b *BidiStreamForClient[Req, Res]) Send(msg *Req) error {
+func (b *ClientBidiStream[Req, Res]) Send(msg *Req) error {
 	if b.err != nil {
 		return b.err
 	}
@@ -159,7 +159,7 @@ func (b *BidiStreamForClient[Req, Res]) Send(msg *Req) error {
 }
 
 // CloseSend closes the send side of the stream.
-func (b *BidiStreamForClient[Req, Res]) CloseSend() error {
+func (b *ClientBidiStream[Req, Res]) CloseSend() error {
 	if b.err != nil {
 		return b.err
 	}
@@ -168,7 +168,7 @@ func (b *BidiStreamForClient[Req, Res]) CloseSend() error {
 
 // Receive a message. When the server is done sending messages and no other
 // errors have occurred, Receive will return an error that wraps io.EOF.
-func (b *BidiStreamForClient[Req, Res]) Receive() (*Res, error) {
+func (b *ClientBidiStream[Req, Res]) Receive() (*Res, error) {
 	if b.err != nil {
 		return nil, b.err
 	}
@@ -180,7 +180,7 @@ func (b *BidiStreamForClient[Req, Res]) Receive() (*Res, error) {
 }
 
 // CloseReceive closes the receive side of the stream.
-func (b *BidiStreamForClient[Req, Res]) CloseReceive() error {
+func (b *ClientBidiStream[Req, Res]) CloseReceive() error {
 	if b.err != nil {
 		return b.err
 	}
@@ -189,13 +189,13 @@ func (b *BidiStreamForClient[Req, Res]) CloseReceive() error {
 
 // ResponseHeader returns the headers received from the server. It blocks until
 // the first call to Receive returns.
-func (b *BidiStreamForClient[Req, Res]) ResponseHeader() http.Header {
+func (b *ClientBidiStream[Req, Res]) ResponseHeader() http.Header {
 	return b.receiver.Header()
 }
 
 // ResponseTrailer returns the trailers received from the server. Trailers
 // aren't fully populated until Receive() returns an error wrapping io.EOF.
-func (b *BidiStreamForClient[Req, Res]) ResponseTrailer() http.Header {
+func (b *ClientBidiStream[Req, Res]) ResponseTrailer() http.Header {
 	if trailer, ok := b.receiver.Trailer(); ok {
 		return trailer
 	}

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -265,20 +265,20 @@ func clientSignature(g *protogen.GeneratedFile, method *protogen.Method, named b
 	if method.Desc.IsStreamingClient() && method.Desc.IsStreamingServer() {
 		// bidi streaming
 		return method.GoName + "(" + ctxName + " " + g.QualifiedGoIdent(contextPackage.Ident("Context")) + ") " +
-			"*" + g.QualifiedGoIdent(connectPackage.Ident("BidiStreamForClient")) +
+			"*" + g.QualifiedGoIdent(connectPackage.Ident("ClientBidiStream")) +
 			"[" + g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent) + "]"
 	}
 	if method.Desc.IsStreamingClient() {
 		// client streaming
 		return method.GoName + "(" + ctxName + " " + g.QualifiedGoIdent(contextPackage.Ident("Context")) + ") " +
-			"*" + g.QualifiedGoIdent(connectPackage.Ident("ClientStreamForClient")) +
+			"*" + g.QualifiedGoIdent(connectPackage.Ident("ClientClientStream")) +
 			"[" + g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent) + "]"
 	}
 	if method.Desc.IsStreamingServer() {
 		return method.GoName + "(" + ctxName + " " + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
 			", " + reqName + " *" + g.QualifiedGoIdent(connectPackage.Ident("Request")) + "[" +
 			g.QualifiedGoIdent(method.Input.GoIdent) + "]) " +
-			"(*" + g.QualifiedGoIdent(connectPackage.Ident("ServerStreamForClient")) +
+			"(*" + g.QualifiedGoIdent(connectPackage.Ident("ClientServerStream")) +
 			"[" + g.QualifiedGoIdent(method.Output.GoIdent) + "]" +
 			", error)"
 	}

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -526,7 +526,7 @@ func (p *pluggablePingServer) Ping(
 	return p.ping(ctx, request)
 }
 
-func failNoHTTP2(tb testing.TB, stream *connect.BidiStreamForClient[pingv1.CumSumRequest, pingv1.CumSumResponse]) {
+func failNoHTTP2(tb testing.TB, stream *connect.ClientBidiStream[pingv1.CumSumRequest, pingv1.CumSumResponse]) {
 	tb.Helper()
 	if err := stream.Send(&pingv1.CumSumRequest{}); err != nil {
 		assert.ErrorIs(tb, err, io.EOF)

--- a/internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go
@@ -46,11 +46,11 @@ type PingServiceClient interface {
 	// Fail always fails.
 	Fail(context.Context, *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context) *connect_go.ClientStreamForClient[v1.SumRequest, v1.SumResponse]
+	Sum(context.Context) *connect_go.ClientClientStream[v1.SumRequest, v1.SumResponse]
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect_go.Request[v1.CountUpRequest]) (*connect_go.ServerStreamForClient[v1.CountUpResponse], error)
+	CountUp(context.Context, *connect_go.Request[v1.CountUpRequest]) (*connect_go.ClientServerStream[v1.CountUpResponse], error)
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
-	CumSum(context.Context) *connect_go.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse]
+	CumSum(context.Context) *connect_go.ClientBidiStream[v1.CumSumRequest, v1.CumSumResponse]
 }
 
 // NewPingServiceClient constructs a client for the connect.ping.v1.PingService service. By default,
@@ -111,17 +111,17 @@ func (c *pingServiceClient) Fail(ctx context.Context, req *connect_go.Request[v1
 }
 
 // Sum calls connect.ping.v1.PingService.Sum.
-func (c *pingServiceClient) Sum(ctx context.Context) *connect_go.ClientStreamForClient[v1.SumRequest, v1.SumResponse] {
+func (c *pingServiceClient) Sum(ctx context.Context) *connect_go.ClientClientStream[v1.SumRequest, v1.SumResponse] {
 	return c.sum.CallClientStream(ctx)
 }
 
 // CountUp calls connect.ping.v1.PingService.CountUp.
-func (c *pingServiceClient) CountUp(ctx context.Context, req *connect_go.Request[v1.CountUpRequest]) (*connect_go.ServerStreamForClient[v1.CountUpResponse], error) {
+func (c *pingServiceClient) CountUp(ctx context.Context, req *connect_go.Request[v1.CountUpRequest]) (*connect_go.ClientServerStream[v1.CountUpResponse], error) {
 	return c.countUp.CallServerStream(ctx, req)
 }
 
 // CumSum calls connect.ping.v1.PingService.CumSum.
-func (c *pingServiceClient) CumSum(ctx context.Context) *connect_go.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse] {
+func (c *pingServiceClient) CumSum(ctx context.Context) *connect_go.ClientBidiStream[v1.CumSumRequest, v1.CumSumResponse] {
 	return c.cumSum.CallBidiStream(ctx)
 }
 


### PR DESCRIPTION
Rather than `ServerStreamForClient`, change to `ClientServerStream`
(with similar changes for server and bidi streaming).

I'm unsure about this - it's not clear to me that we're making things
better. The names are definitely shorter, but I think we may be losing a
little clarity? (Frankly, I'm also a little embarrassed to ship
`ClientClientStream`.)

Fixes TCN-65