### PR TITLE
Revert change in client stream names

### DIFF
--- a/client.go
+++ b/client.go
@@ -115,16 +115,16 @@ func (c *Client[Req, Res]) CallUnary(ctx context.Context, request *Request[Req])
 }
 
 // CallClientStream calls a client streaming procedure.
-func (c *Client[Req, Res]) CallClientStream(ctx context.Context) *ClientClientStream[Req, Res] {
+func (c *Client[Req, Res]) CallClientStream(ctx context.Context) *ClientStreamForClient[Req, Res] {
 	if c.err != nil {
-		return &ClientClientStream[Req, Res]{err: c.err}
+		return &ClientStreamForClient[Req, Res]{err: c.err}
 	}
 	sender, receiver := c.newStream(ctx, StreamTypeClient)
-	return &ClientClientStream[Req, Res]{sender: sender, receiver: receiver}
+	return &ClientStreamForClient[Req, Res]{sender: sender, receiver: receiver}
 }
 
 // CallServerStream calls a server streaming procedure.
-func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Request[Req]) (*ClientServerStream[Res], error) {
+func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Request[Req]) (*ServerStreamForClient[Res], error) {
 	if c.err != nil {
 		return nil, c.err
 	}
@@ -141,16 +141,16 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 	if err := sender.Close(nil); err != nil {
 		return nil, err
 	}
-	return &ClientServerStream[Res]{receiver: receiver}, nil
+	return &ServerStreamForClient[Res]{receiver: receiver}, nil
 }
 
 // CallBidiStream calls a bidirectional streaming procedure.
-func (c *Client[Req, Res]) CallBidiStream(ctx context.Context) *ClientBidiStream[Req, Res] {
+func (c *Client[Req, Res]) CallBidiStream(ctx context.Context) *BidiStreamForClient[Req, Res] {
 	if c.err != nil {
-		return &ClientBidiStream[Req, Res]{err: c.err}
+		return &BidiStreamForClient[Req, Res]{err: c.err}
 	}
 	sender, receiver := c.newStream(ctx, StreamTypeBidi)
-	return &ClientBidiStream[Req, Res]{sender: sender, receiver: receiver}
+	return &BidiStreamForClient[Req, Res]{sender: sender, receiver: receiver}
 }
 
 func (c *Client[Req, Res]) newStream(ctx context.Context, streamType StreamType) (Sender, Receiver) {

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -265,20 +265,20 @@ func clientSignature(g *protogen.GeneratedFile, method *protogen.Method, named b
 	if method.Desc.IsStreamingClient() && method.Desc.IsStreamingServer() {
 		// bidi streaming
 		return method.GoName + "(" + ctxName + " " + g.QualifiedGoIdent(contextPackage.Ident("Context")) + ") " +
-			"*" + g.QualifiedGoIdent(connectPackage.Ident("ClientBidiStream")) +
+			"*" + g.QualifiedGoIdent(connectPackage.Ident("BidiStreamForClient")) +
 			"[" + g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent) + "]"
 	}
 	if method.Desc.IsStreamingClient() {
 		// client streaming
 		return method.GoName + "(" + ctxName + " " + g.QualifiedGoIdent(contextPackage.Ident("Context")) + ") " +
-			"*" + g.QualifiedGoIdent(connectPackage.Ident("ClientClientStream")) +
+			"*" + g.QualifiedGoIdent(connectPackage.Ident("ClientStreamForClient")) +
 			"[" + g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent) + "]"
 	}
 	if method.Desc.IsStreamingServer() {
 		return method.GoName + "(" + ctxName + " " + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
 			", " + reqName + " *" + g.QualifiedGoIdent(connectPackage.Ident("Request")) + "[" +
 			g.QualifiedGoIdent(method.Input.GoIdent) + "]) " +
-			"(*" + g.QualifiedGoIdent(connectPackage.Ident("ClientServerStream")) +
+			"(*" + g.QualifiedGoIdent(connectPackage.Ident("ServerStreamForClient")) +
 			"[" + g.QualifiedGoIdent(method.Output.GoIdent) + "]" +
 			", error)"
 	}

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -534,7 +534,7 @@ func (p *pluggablePingServer) Ping(
 	return p.ping(ctx, request)
 }
 
-func failNoHTTP2(tb testing.TB, stream *connect.ClientBidiStream[pingv1.CumSumRequest, pingv1.CumSumResponse]) {
+func failNoHTTP2(tb testing.TB, stream *connect.BidiStreamForClient[pingv1.CumSumRequest, pingv1.CumSumResponse]) {
 	tb.Helper()
 	if err := stream.Send(&pingv1.CumSumRequest{}); err != nil {
 		assert.ErrorIs(tb, err, io.EOF)

--- a/internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go
@@ -46,11 +46,11 @@ type PingServiceClient interface {
 	// Fail always fails.
 	Fail(context.Context, *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context) *connect_go.ClientClientStream[v1.SumRequest, v1.SumResponse]
+	Sum(context.Context) *connect_go.ClientStreamForClient[v1.SumRequest, v1.SumResponse]
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect_go.Request[v1.CountUpRequest]) (*connect_go.ClientServerStream[v1.CountUpResponse], error)
+	CountUp(context.Context, *connect_go.Request[v1.CountUpRequest]) (*connect_go.ServerStreamForClient[v1.CountUpResponse], error)
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
-	CumSum(context.Context) *connect_go.ClientBidiStream[v1.CumSumRequest, v1.CumSumResponse]
+	CumSum(context.Context) *connect_go.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse]
 }
 
 // NewPingServiceClient constructs a client for the connect.ping.v1.PingService service. By default,
@@ -111,17 +111,17 @@ func (c *pingServiceClient) Fail(ctx context.Context, req *connect_go.Request[v1
 }
 
 // Sum calls connect.ping.v1.PingService.Sum.
-func (c *pingServiceClient) Sum(ctx context.Context) *connect_go.ClientClientStream[v1.SumRequest, v1.SumResponse] {
+func (c *pingServiceClient) Sum(ctx context.Context) *connect_go.ClientStreamForClient[v1.SumRequest, v1.SumResponse] {
 	return c.sum.CallClientStream(ctx)
 }
 
 // CountUp calls connect.ping.v1.PingService.CountUp.
-func (c *pingServiceClient) CountUp(ctx context.Context, req *connect_go.Request[v1.CountUpRequest]) (*connect_go.ClientServerStream[v1.CountUpResponse], error) {
+func (c *pingServiceClient) CountUp(ctx context.Context, req *connect_go.Request[v1.CountUpRequest]) (*connect_go.ServerStreamForClient[v1.CountUpResponse], error) {
 	return c.countUp.CallServerStream(ctx, req)
 }
 
 // CumSum calls connect.ping.v1.PingService.CumSum.
-func (c *pingServiceClient) CumSum(ctx context.Context) *connect_go.ClientBidiStream[v1.CumSumRequest, v1.CumSumResponse] {
+func (c *pingServiceClient) CumSum(ctx context.Context) *connect_go.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse] {
 	return c.cumSum.CallBidiStream(ctx)
 }
 


### PR DESCRIPTION
The change to client stream names is overall worse. The docs are worse, the
names are more confusing in context, and `ClientClientStream` is a particular
wart. Revert!

This reverts commit e4f4f5438e7a9c4c4b030384f4062534a1122c3c.
