### PR TITLE
Update golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,14 +3,14 @@ run:
 linters-settings:
   errcheck:
     check-type-assertions: true
-  exhaustivestruct:
-    struct-patterns:
+  exhaustruct:
+    include:
       # No zero values for param structs.
-      - 'github.com/bufbuild/connect-go.*[pP]arams'
+      - 'github\.com/bufbuild/connect-go\..*[pP]arams'
       # No zero values for ClientStream, ServerStream, and friends.
-      - 'github.com/bufbuild/connect-go.ClientStream*'
-      - 'github.com/bufbuild/connect-go.ServerStream*'
-      - 'github.com/bufbuild/connect-go.BidiStream*'
+      - 'github\.com/bufbuild/connect-go\.ClientStream.*'
+      - 'github\.com/bufbuild/connect-go\.ServerStream.*'
+      - 'github\.com/bufbuild/connect-go\.BidiStream.*'
   forbidigo:
     forbid:
       - '^fmt\.Print'
@@ -30,22 +30,23 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - cyclop        # covered by gocyclo
-    - funlen        # rely on code review to limit function length
-    - gocognit      # dubious "cognitive overhead" quantification
-    - gofumpt       # prefer standard gofmt
-    - golint        # deprecated by Go team
-    - gomnd         # some unnamed constants are okay
-    - interfacer    # deprecated by author
-    - ireturn       # "accept interfaces, return structs" isn't ironclad
-    - lll           # don't want hard limits for line length
-    - maintidx      # covered by gocyclo
-    - maligned      # readability trumps efficient struct packing
-    - nlreturn      # generous whitespace violates house style
-    - scopelint     # deprecated by author
-    - testpackage   # internal tests are fine
-    - wrapcheck     # don't _always_ need to wrap errors
-    - wsl           # generous whitespace violates house style
+    - cyclop            # covered by gocyclo
+    - exhaustivestruct  # replaced by exhaustruct
+    - funlen            # rely on code review to limit function length
+    - gocognit          # dubious "cognitive overhead" quantification
+    - gofumpt           # prefer standard gofmt
+    - golint            # deprecated by Go team
+    - gomnd             # some unnamed constants are okay
+    - interfacer        # deprecated by author
+    - ireturn           # "accept interfaces, return structs" isn't ironclad
+    - lll               # don't want hard limits for line length
+    - maintidx          # covered by gocyclo
+    - maligned          # readability trumps efficient struct packing
+    - nlreturn          # generous whitespace violates house style
+    - scopelint         # deprecated by author
+    - testpackage       # internal tests are fine
+    - wrapcheck         # don't _always_ need to wrap errors
+    - wsl               # generous whitespace violates house style
 issues:
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining

--- a/Makefile
+++ b/Makefile
@@ -84,16 +84,16 @@ $(BIN)/protoc-gen-connect-go:
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.3.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.4.0
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.3.0
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.4.0
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/protocol.go
+++ b/protocol.go
@@ -251,7 +251,7 @@ func validateRequestURL(uri string) *Error {
 // negotiateCompression determines and validates the request compression and
 // response compression using the available compressors and protocol-specific
 // Content-Encoding and Accept-Encoding headers.
-func negotiateCompression(
+func negotiateCompression( // nolint:nonamedreturns
 	availableCompressors readOnlyCompressionPools,
 	sent, accept string,
 ) (requestCompression, responseCompression string, clientVisibleErr *Error) {


### PR DESCRIPTION
Ref: https://linear.app/bufbuild/issue/TCN-96/upgrade-golangci-lint-in-connect-go-to-v1462-and-fix-or-ignore-issues
