### PR TITLE
Revert "Export AsError (#215)"

### DIFF
--- a/code.go
+++ b/code.go
@@ -261,7 +261,7 @@ func (c *Code) UnmarshalText(data []byte) error {
 // CodeOf returns the error's status code if it is or wraps a *connect.Error
 // and CodeUnknown otherwise.
 func CodeOf(err error) Code {
-	if connectErr, ok := AsError(err); ok {
+	if connectErr, ok := asError(err); ok {
 		return connectErr.Code()
 	}
 	return CodeUnknown

--- a/envelope.go
+++ b/envelope.go
@@ -93,7 +93,7 @@ func (w *envelopeWriter) write(env *envelope) *Error {
 	prefix[0] = env.Flags
 	binary.BigEndian.PutUint32(prefix[1:5], uint32(env.Data.Len()))
 	if _, err := w.writer.Write(prefix[:]); err != nil {
-		if connectErr, ok := AsError(err); ok {
+		if connectErr, ok := asError(err); ok {
 			return connectErr
 		}
 		return errorf(CodeUnknown, "write envelope: %w", err)
@@ -190,7 +190,7 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 		return NewError(CodeUnknown, err)
 	case err != nil || prefixBytesRead < 5:
 		// Something else has gone wrong - the stream didn't end cleanly.
-		if connectErr, ok := AsError(err); ok {
+		if connectErr, ok := asError(err); ok {
 			return connectErr
 		}
 		return errorf(

--- a/error_test.go
+++ b/error_test.go
@@ -61,7 +61,7 @@ func TestErrorCode(t *testing.T) {
 		"another: %w",
 		NewError(CodeUnavailable, errors.New("foo")),
 	)
-	connectErr, ok := AsError(err)
+	connectErr, ok := asError(err)
 	assert.True(t, ok)
 	assert.Equal(t, connectErr.Code(), CodeUnavailable)
 }

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -488,7 +488,7 @@ func (r *connectStreamingHandlerReceiver) Close() error {
 	// an error for a streaming RPC. Better to accept that we can't always reuse
 	// TCP connections.
 	if err := r.request.Body.Close(); err != nil {
-		if connectErr, ok := AsError(err); ok {
+		if connectErr, ok := asError(err); ok {
 			return connectErr
 		}
 		return NewError(CodeUnknown, err)
@@ -628,7 +628,7 @@ func (s *connectUnaryHandlerSender) Close(err error) error {
 	s.responseWriter.Header().Set(headerContentType, connectUnaryContentTypeJSON)
 	s.responseWriter.WriteHeader(connectCodeToHTTP(CodeOf(err)))
 	var wire *connectWireError
-	if connectErr, ok := AsError(err); ok {
+	if connectErr, ok := asError(err); ok {
 		wire = (*connectWireError)(connectErr)
 	} else {
 		wire = (*connectWireError)(NewError(CodeUnknown, err))
@@ -644,7 +644,7 @@ func (s *connectUnaryHandlerSender) Close(err error) error {
 func (s *connectUnaryHandlerSender) writeHeader(err error) {
 	header := s.responseWriter.Header()
 	if err != nil {
-		if connectErr, ok := AsError(err); ok {
+		if connectErr, ok := asError(err); ok {
 			mergeHeaders(header, connectErr.meta)
 		}
 	}
@@ -689,7 +689,7 @@ type connectStreamingMarshaler struct {
 func (m *connectStreamingMarshaler) MarshalEndStream(err error, trailer http.Header) *Error {
 	end := &connectEndStreamMessage{Trailer: trailer}
 	if err != nil {
-		if connectErr, ok := AsError(err); ok {
+		if connectErr, ok := asError(err); ok {
 			mergeHeaders(end.Trailer, connectErr.meta)
 			end.Error = (*connectWireError)(connectErr)
 		} else {
@@ -776,7 +776,7 @@ func (m *connectUnaryMarshaler) Marshal(message any) *Error {
 
 func (m *connectUnaryMarshaler) write(data []byte) *Error {
 	if _, err := m.writer.Write(data); err != nil {
-		if connectErr, ok := AsError(err); ok {
+		if connectErr, ok := asError(err); ok {
 			return connectErr
 		}
 		return errorf(CodeUnknown, "write message: %w", err)
@@ -805,7 +805,7 @@ func (u *connectUnaryUnmarshaler) UnmarshalFunc(message any, unmarshal func([]by
 	defer u.bufferPool.Put(data)
 	// ReadFrom ignores io.EOF, so any error here is real.
 	if _, err := data.ReadFrom(u.reader); err != nil {
-		if connectErr, ok := AsError(err); ok {
+		if connectErr, ok := asError(err); ok {
 			return connectErr
 		}
 		return errorf(CodeUnknown, "read message: %w", err)
@@ -831,7 +831,7 @@ func (e *connectWireError) MarshalJSON() ([]byte, error) {
 		Code:    CodeUnknown.String(),
 		Message: (*Error)(e).Error(),
 	}
-	if connectErr, ok := AsError((*Error)(e)); ok {
+	if connectErr, ok := asError((*Error)(e)); ok {
 		wire.Code = connectErr.Code().String()
 		wire.Message = connectErr.Message()
 		details, err := connectErr.detailsAsAny()

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -884,7 +884,7 @@ func grpcErrorToTrailer(bufferPool *bufferPool, trailer http.Header, protobuf Co
 		)
 		return
 	}
-	if connectErr, ok := AsError(err); ok {
+	if connectErr, ok := asError(err); ok {
 		mergeHeaders(trailer, connectErr.meta)
 	}
 	trailer.Set(grpcHeaderStatus, code)
@@ -897,7 +897,7 @@ func grpcStatusFromError(err error) (*statusv1.Status, error) {
 		Code:    int32(CodeUnknown),
 		Message: err.Error(),
 	}
-	if connectErr, ok := AsError(err); ok {
+	if connectErr, ok := asError(err); ok {
 		status.Code = int32(connectErr.Code())
 		status.Message = connectErr.Message()
 		details, err := connectErr.detailsAsAny()


### PR DESCRIPTION
After a lot of internal back-and-forth, we're reverting this change. We can
always re-export `AsError` once the community has a chance to kick the tires
more.

This reverts commit f574e7a45b72a9ed7436411a35d10adee61d25bc.
