### PR TITLE
Use streaming Content-Type from protocol

### DIFF
--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -42,7 +42,7 @@ const (
 
 	connectUnaryContentTypePrefix     = "application/"
 	connectUnaryContentTypeJSON       = connectUnaryContentTypePrefix + "json"
-	connectStreamingContentTypePrefix = "application/connectstream+"
+	connectStreamingContentTypePrefix = "application/connect+"
 )
 
 type protocolConnect struct{}


### PR DESCRIPTION
Ooops! I used a content-type from an old draft.
