### PR TITLE
Improve client streaming ergonomics

### DIFF
--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -350,7 +350,7 @@ func generateUnimplementedServerImplementation(g *protogen.GeneratedFile, servic
 	g.P()
 	for _, method := range service.Methods {
 		g.P("func (", names.UnimplementedServer, ") ", serverSignature(g, method), "{")
-		if method.Desc.IsStreamingServer() || method.Desc.IsStreamingClient() {
+		if method.Desc.IsStreamingServer() {
 			g.P("return ", connectPackage.Ident("NewError"), "(",
 				connectPackage.Ident("CodeUnimplemented"), ", ", errorsPackage.Ident("New"),
 				`("`, method.Desc.FullName(), ` is not implemented"))`)
@@ -387,8 +387,8 @@ func serverSignatureParams(g *protogen.GeneratedFile, method *protogen.Method, n
 		// client streaming
 		return "(" + ctxName + g.QualifiedGoIdent(contextPackage.Ident("Context")) + ", " +
 			streamName + "*" + g.QualifiedGoIdent(connectPackage.Ident("ClientStream")) +
-			"[" + g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent) + "]" +
-			") error"
+			"[" + g.QualifiedGoIdent(method.Input.GoIdent) + "]" +
+			") (*" + g.QualifiedGoIdent(connectPackage.Ident("Response")) + "[" + g.QualifiedGoIdent(method.Output.GoIdent) + "] ,error)"
 	}
 	if method.Desc.IsStreamingServer() {
 		// server streaming

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -607,11 +607,11 @@ func (p pingServer) Fail(ctx context.Context, request *connect.Request[pingv1.Fa
 
 func (p pingServer) Sum(
 	ctx context.Context,
-	stream *connect.ClientStream[pingv1.SumRequest, pingv1.SumResponse],
-) error {
+	stream *connect.ClientStream[pingv1.SumRequest],
+) (*connect.Response[pingv1.SumResponse], error) {
 	if p.checkMetadata {
 		if err := expectMetadata(stream.RequestHeader(), "header", clientHeader, headerValue); err != nil {
-			return err
+			return nil, err
 		}
 	}
 	var sum int64
@@ -619,12 +619,12 @@ func (p pingServer) Sum(
 		sum += stream.Msg().Number
 	}
 	if stream.Err() != nil {
-		return stream.Err()
+		return nil, stream.Err()
 	}
 	response := connect.NewResponse(&pingv1.SumResponse{Sum: sum})
 	response.Header().Set(handlerHeader, headerValue)
 	response.Trailer().Set(handlerTrailer, trailerValue)
-	return stream.SendAndClose(response)
+	return response, nil
 }
 
 func (p pingServer) CountUp(

--- a/internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go
@@ -132,7 +132,7 @@ type PingServiceHandler interface {
 	// Fail always fails.
 	Fail(context.Context, *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context, *connect_go.ClientStream[v1.SumRequest, v1.SumResponse]) error
+	Sum(context.Context, *connect_go.ClientStream[v1.SumRequest]) (*connect_go.Response[v1.SumResponse], error)
 	// CountUp returns a stream of the numbers up to the given request.
 	CountUp(context.Context, *connect_go.Request[v1.CountUpRequest], *connect_go.ServerStream[v1.CountUpResponse]) error
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
@@ -185,8 +185,8 @@ func (UnimplementedPingServiceHandler) Fail(context.Context, *connect_go.Request
 	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Fail is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) Sum(context.Context, *connect_go.ClientStream[v1.SumRequest, v1.SumResponse]) error {
-	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum is not implemented"))
+func (UnimplementedPingServiceHandler) Sum(context.Context, *connect_go.ClientStream[v1.SumRequest]) (*connect_go.Response[v1.SumResponse], error) {
+	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum is not implemented"))
 }
 
 func (UnimplementedPingServiceHandler) CountUp(context.Context, *connect_go.Request[v1.CountUpRequest], *connect_go.ServerStream[v1.CountUpResponse]) error {


### PR DESCRIPTION
Rather than having handlers implementing client streaming methods call a
method to send the response, make things more like unary: they should
just return `(response, error)`.
