### PR TITLE
Special-case errors where h2c is not configured and where connect.WithGRPC is not used

### DIFF
--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -236,7 +236,7 @@ func (d *duplexHTTPCall) makeRequest() {
 	response, err := d.httpClient.Do(d.request)
 	if err != nil {
 		err = wrapIfContextError(err)
-		err = wrapIfLikelyH2CNotConfiguredError(err)
+		err = wrapIfLikelyH2CNotConfiguredError(d.request, err)
 		err = wrapIfLikelyWithGRPCNotUsedError(err)
 		if _, ok := asError(err); !ok {
 			err = NewError(CodeUnavailable, err)

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -236,6 +236,7 @@ func (d *duplexHTTPCall) makeRequest() {
 	response, err := d.httpClient.Do(d.request)
 	if err != nil {
 		err = wrapIfContextError(err)
+		err = wrapIfLikelyH2CNotConfiguredError(err)
 		if _, ok := asError(err); !ok {
 			err = NewError(CodeUnavailable, err)
 		}

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -237,6 +237,7 @@ func (d *duplexHTTPCall) makeRequest() {
 	if err != nil {
 		err = wrapIfContextError(err)
 		err = wrapIfLikelyH2CNotConfiguredError(err)
+		err = wrapIfLikelyWithGRPCNotUsedError(err)
 		if _, ok := asError(err); !ok {
 			err = NewError(CodeUnavailable, err)
 		}

--- a/error.go
+++ b/error.go
@@ -218,8 +218,7 @@ func wrapIfLikelyH2CNotConfiguredError(err error) error {
 	if errString := err.Error(); strings.HasPrefix(errString, `Post "`) &&
 		(strings.Contains(errString, `net/http: HTTP/1.x transport connection broken: malformed HTTP response`) ||
 			strings.HasSuffix(errString, `write: broken pipe`)) {
-		return fmt.Errorf("You likely have not configured h2c, see %s: %w", commonErrorsURL, err)
-
+		return fmt.Errorf("you likely have not configured h2c, see %s: %w", commonErrorsURL, err)
 	}
 	return err
 }
@@ -242,8 +241,7 @@ func wrapIfLikelyWithGRPCNotUsedError(err error) error {
 	if errString := err.Error(); strings.HasPrefix(errString, `Post "`) &&
 		strings.Contains(errString, `http2: Transport: cannot retry err`) &&
 		strings.HasSuffix(errString, `after Request.Body was written; define Request.GetBody to avoid this error`) {
-		return fmt.Errorf("You likely are talking to a gRPC server without using the connect.WithGRPC() client option, see %s: %w", commonErrorsURL, err)
-
+		return fmt.Errorf("you likely are talking to a gRPC server without using the connect.WithGRPC() client option, see %s: %w", commonErrorsURL, err)
 	}
 	return err
 }

--- a/error.go
+++ b/error.go
@@ -213,8 +213,8 @@ func wrapIfLikelyH2CNotConfiguredError(request *http.Request, err error) error {
 	if _, ok := asError(err); ok {
 		return err
 	}
-	if url := request.URL; url != nil && url.Scheme == "https" {
-		// If the scheme is https, we definitely do not have an h2c error, so just return.
+	if url := request.URL; url != nil && url.Scheme != "http" {
+		// If the scheme is not http, we definitely do not have an h2c error, so just return.
 		return err
 	}
 	// net/http code has been investigated and there is no typing of any of these errors

--- a/error.go
+++ b/error.go
@@ -215,6 +215,7 @@ func wrapIfLikelyH2CNotConfiguredError(err error) error {
 	}
 	// net/http code has been investigated and there is no typing of any of these errors
 	// they are all created with fmt.Errorf
+	// grpc-go returns the first error 2/3-3/4 of the time, and the second error 1/4-1/3 of the time
 	if errString := err.Error(); strings.HasPrefix(errString, `Post "`) &&
 		(strings.Contains(errString, `net/http: HTTP/1.x transport connection broken: malformed HTTP response`) ||
 			strings.HasSuffix(errString, `write: broken pipe`)) {


### PR DESCRIPTION
This is pretty hacky, but it works. A few notes:

- Adding a test for this is a little difficult I think since it requires grpc-go to be reproduced, but we can talk about it.
- We will need to update the docs link.
- I prefixed the error instead of suffixed so I could use `%w`, let me know your thoughts.