### PR TITLE
Docs & README

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,9 @@ issues:
     - linters: [varnamelen]
       path: cmd/protoc-gen-connect-go
       text: "parameter name 'g' is too short"
+    # It should be crystal clear that Connect uses plain *http.Clients.
+    - linters: [revive, stylecheck]
+      path: client_example_test.go
     # Doesn't work with type parameters.
     # TODO: re-enable when working.
     - linters:

--- a/LICENSE
+++ b/LICENSE
@@ -199,4 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/README.md
+++ b/README.md
@@ -5,4 +5,147 @@ Connect
 [![Report Card](https://goreportcard.com/badge/github.com/bufbuild/connect-go)](https://goreportcard.com/report/github.com/bufbuild/connect-go)
 [![GoDoc](https://pkg.go.dev/badge/github.com/bufbuild/connect-go.svg)](https://pkg.go.dev/github.com/bufbuild/connect-go)
 
-WIP: Not ready for consumption.
+Connect is a small framework for building HTTP APIs. You write a short API
+definition file and implement your application logic, and Connect generates
+code to handle marshaling, routing, error handling, and content type
+negotiation. It also generates an idiomatic, type-safe client.
+
+Connect is wire compatible with the [gRPC][grpc] protocol, including streaming.
+Connect servers interoperate seamlessly with generated clients in [more than a
+dozen languages][grpc-implementations], command-line tools like [grpcurl],
+and proxies like [Envoy][envoy] and [gRPC-Gateway][grpc-gateway]. They also
+support gRPC-Web natively, so they can serve browser traffic without a
+translating proxy. Connect clients work with any gRPC or gRPC-Web server.
+
+Under the hood, Connect is just [Protocol Buffers][protobuf] and the standard
+library: no custom HTTP implementation, no new name resolution or load
+balancing APIs, and no surprises. Everything you already know about `net/http`
+still applies, and any package that works with an `http.Server`, `http.Client`,
+or `http.Handler` also works with Connect.
+
+For more on Connect, including a walkthrough and a comparison to alternatives,
+see the [docs].
+
+## A small example
+
+Curious what all this looks like in practice? From a [Protobuf
+schema](internal/proto/connect/ping/v1/ping.proto), we generate [a small RPC
+package](internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go). Using that
+package, we can build a server:
+
+```go
+package main
+
+import (
+  "log"
+  "net/http"
+
+  "github.com/bufbuild/connect-go"
+  "github.com/bufbuild/connect-go/internal/gen/connect/connect/ping/v1/pingv1connect"
+  pingv1 "github.com/bufbuild/connect-go/internal/gen/go/connect/ping/v1"
+)
+
+type PingServer struct {
+  pingv1connect.UnimplementedPingServiceHandler // returns errors from all methods
+}
+
+func (ps *PingServer) Ping(
+  ctx context.Context,
+  req *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
+  // connect.Request and connect.Response give you direct access to headers and
+  // trailers. No context-based nonsense!
+  log.Println(req.Header().Get("Some-Header"))
+  res := connect.NewResponse(&pingv1.PingResponse{
+    // req.Msg is a strongly-typed *pingv1.PingRequest, so we can access its
+    // fields without type assertions.
+    Number: req.Msg.Number,
+  })
+  res.Header().Set("Some-Other-Header", "hello!")
+  res.Trailer().Set("Some-Trailer", "goodbye!")
+  return res, nil
+}
+
+func main() {
+  mux := http.NewServeMux()
+  // The generated constructors return a path and a plain net/http
+  // handler.
+  mux.Handle(pingv1.NewPingServiceHandler(&PingServer{}))
+  http.ListenAndServeTLS(":8081", "server.crt", "server.key", mux)
+}
+```
+
+With that server running, you can make requests with any gRPC client. Using
+Connect,
+
+```go
+package main
+
+import (
+  "log"
+  "net/http"
+
+  "github.com/bufbuild/connect-go"
+  "github.com/bufbuild/connect-go/internal/gen/connect/connect/ping/v1/pingv1connect"
+  pingv1 "github.com/bufbuild/connect-go/internal/gen/go/connect/ping/v1"
+)
+
+func main() {
+  client, err := pingv1connect.NewPingServiceClient(
+    http.DefaultClient,
+    "https://localhost:8081/",
+  )
+  if err != nil {
+    log.Fatalln(err)
+  }
+  req := connect.NewRequest(&pingv1.PingRequest{
+    Number: 42,
+  })
+  req.Header().Set("Some-Header", "hello from connect")
+  res, err := client.Ping(context.Background(), req)
+  if err != nil {
+    log.Fatalln(err)
+  }
+  log.Println(res.Msg)
+  log.Println(res.Header().Get("Some-Other-Header"))
+  log.Println(res.Trailer().Get("Some-Trailer"))
+}
+```
+
+You can find production-ready examples of [servers][prod-server] and
+[clients][prod-client] in the API documentation.
+
+## Status
+
+Connect is in _beta_: we use it internally, but expect the Go community to
+discover new patterns for working with generics in the coming months. We plan
+to tag a release candidate in July 2022 and stable v1 soon after the Go 1.19
+release.
+
+## Support and versioning
+
+Connect supports:
+
+* The [two most recent major releases][go-support-policy] of Go, with a minimum
+  of Go 1.18.
+* [APIv2] of Protocol Buffers in Go (`google.golang.org/protobuf`).
+
+Within those parameters, Connect follows semantic versioning. We make no
+exceptions for deprecated or experimental APIs.
+
+## Legal
+
+Offered under the [Apache 2 license][license].
+
+[APIv2]: https://blog.golang.org/protobuf-apiv2
+[docs]: https://bufconnect.com
+[envoy]: https://www.envoyproxy.io/
+[godoc]: https://pkg.go.dev/github.com/bufbuild/connect-go
+[go-support-policy]: https://golang.org/doc/devel/release#policy
+[grpc-gateway]: https://grpc-ecosystem.github.io/grpc-gateway/
+[grpc]: https://grpc.io/
+[grpc-implementations]: https://grpc.io/docs/languages/
+[grpcurl]: https://github.com/fullstorydev/grpcurl
+[license]: https://github.com/bufbuild/connect-go/blob/main/LICENSE.txt
+[prod-client]: https://pkg.go.dev/github.com/bufbuild/connect-go#example-Client
+[prod-server]: https://pkg.go.dev/github.com/bufbuild/connect-go#example-package
+[protobuf]: https://developers.google.com/protocol-buffers

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Connect
 Connect is a slim library for building browser and gRPC-compatible HTTP APIs.
 You write a short [Protocol Buffer][protobuf] schema and implement your
 application logic, and Connect generates code to handle marshaling, routing,
-error handling, and content type negotiation. It also generates an idiomatic,
+compression, and content type negotiation. It also generates an idiomatic,
 type-safe client. Handlers and clients support three protocols: gRPC, gRPC-Web,
 and Connect's own protocol.
 
@@ -149,8 +149,8 @@ configuring timeouts, connection pools, observability, and h2c.
 
 This module is a release candidate: we rely on it in production, but expect the
 Go community to discover new patterns for working with generics in the coming
-months. We plan to tag a further release candidates as necessary and a stable
-v1 soon after the Go 1.19 release.
+months. We plan to tag further release candidates as necessary and a stable v1
+soon after the Go 1.19 release.
 
 ## Support and versioning
 
@@ -160,8 +160,7 @@ v1 soon after the Go 1.19 release.
   of Go 1.18.
 * [APIv2] of Protocol Buffers in Go (`google.golang.org/protobuf`).
 
-Within those parameters, Connect follows semantic versioning. We make no
-exceptions for deprecated or experimental APIs.
+Within those parameters, Connect follows semantic versioning.
 
 ## Legal
 

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/bufbuild/connect-go"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
@@ -28,36 +27,11 @@ import (
 
 func Example_client() {
 	logger := log.New(os.Stdout, "" /* prefix */, 0 /* flags */)
-	// Timeouts, connection pooling, custom dialers, and other low-level
-	// transport details are handled by net/http. Everything you already know
-	// (or everything you learn) about hardening net/http Clients applies to
-	// connect too.
-	//
-	// Of course, you can skip this configuration and use http.DefaultClient for
-	// quick proof-of-concept code.
-	httpClient := &http.Client{
-		Timeout: 5 * time.Second,
-		Transport: &http.Transport{
-			Proxy: nil,
-			// connect handles compression on a per-message basis, so it's a waste to
-			// compress the whole response body.
-			DisableCompression: true,
-			MaxIdleConns:       128,
-			// RPC clients tend to make many requests to few hosts, so allow more
-			// idle connections per host.
-			MaxIdleConnsPerHost:    16,
-			IdleConnTimeout:        90 * time.Second,
-			MaxResponseHeaderBytes: 8 * 1024, // 8 KiB, gRPC's recommended setting
-		},
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			// Don't follow any redirects.
-			return http.ErrUseLastResponse
-		},
-	}
 	// Unfortunately, pkg.go.dev can't run examples that actually use the
 	// network. To keep this example runnable, we'll use an HTTP server and
-	// client that communicate over in-memory pipes. Don't do this in production!
-	httpClient = examplePingServer.Client()
+	// client that communicate over in-memory pipes. The client is still a plain
+	// *http.Client!
+	var httpClient *http.Client = examplePingServer.Client()
 
 	// By default, clients use the Connect protocol. Add connect.WithGRPC() or
 	// connect.WithGRPCWeb() to switch protocols.

--- a/client_stream.go
+++ b/client_stream.go
@@ -149,8 +149,8 @@ func (b *BidiStreamForClient[Req, Res]) RequestHeader() http.Header {
 // headers.
 //
 // If the server returns an error, Send returns an error that wraps io.EOF.
-// Clients should check for case using the standard library's errors.Is and
-// unmarshal the error using Receive.
+// Clients should check for EOF using the standard library's errors.Is and
+// call Receive to retrieve the error.
 func (b *BidiStreamForClient[Req, Res]) Send(msg *Req) error {
 	if b.err != nil {
 		return b.err

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -62,7 +62,7 @@ const (
 	generatedFilenameExtension = ".connect.go"
 	generatedPackageSuffix     = "connect"
 
-	usage = "See https://docs.bufconnect.com for how to use this plugin.\n\nFlags:\n  -h, --help\tPrint this help and exit.\n      --version\tPrint the version and exit."
+	usage = "See https://connect.build/docs/go/getting-started to learn how to use this plugin.\n\nFlags:\n  -h, --help\tPrint this help and exit.\n      --version\tPrint the version and exit."
 
 	commentWidth = 97 // leave room for "// "
 )

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -62,7 +62,7 @@ const (
 	generatedFilenameExtension = ".connect.go"
 	generatedPackageSuffix     = "connect"
 
-	usage = "See the docs for how to use this plugin.\n\nFlags:\n  -h, --help\tPrint this help and exit.\n      --version\tPrint the version and exit."
+	usage = "See https://docs.bufconnect.com for how to use this plugin.\n\nFlags:\n  -h, --help\tPrint this help and exit.\n      --version\tPrint the version and exit."
 
 	commentWidth = 97 // leave room for "// "
 )

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -12,29 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// protoc-gen-connect-go is a plugin for the Protobuf compiler that generates Go code. To use it,
-// build this program and make it available on your PATH as protoc-gen-connect-go.
+// protoc-gen-connect-go is a plugin for the Protobuf compiler that generates
+// Go code. To use it, build this program and make it available on your PATH as
+// protoc-gen-connect-go.
 //
-// The 'connect-go' suffix becomes part of the arguments for the Protobuf compiler. For example,
-// with protoc, alongside the base Go types provided via the protoc-gen-go plugin, you'll invoke it
-// like this:
+// The 'connect-go' suffix becomes part of the arguments for the Protobuf
+// compiler. To generate the base Go types and Connect code using protoc:
 //
-//	 protoc --go_out=go --connect-go_out=connect path/to/file.proto
+//	 protoc --go_out=gen --connect-go_out=gen path/to/file.proto
 //
 // With buf, your buf.gen.yaml will look like this:
 //
 //   version: v1
 //   plugins:
 //     name: go
-//     out: go
+//     out: gen
 //     name: connect-go
-//     out: connect
+//     out: gen
 //
-// This generates service definitions for the Protobuf types and services defined by file.proto. As
-// invoked above, the output will be written to:
+// This generates service definitions for the Protobuf types and services
+// defined by file.proto. If file.proto defines the foov1 Protobuf package, the
+// invocations above will write output to:
 //
-//	 go/path/to/file.pb.go
-//	 connect/path/to/file.connect.go
+//	 gen/path/to/file.pb.go
+//	 gen/path/to/connectfoov1/file.connect.go
 package main
 
 import (

--- a/code.go
+++ b/code.go
@@ -20,51 +20,37 @@ import (
 	"strings"
 )
 
-// A Code is one of gRPC's canonical status codes. There are no user-defined
-// codes, so only the codes enumerated below are valid.
+// A Code is one of the Connect protocol's error codes. There are no user-defined
+// codes, so only the codes enumerated below are valid. In both name and
+// semantics, these codes also match the gRPC status codes.
 //
-// See the specification at
-// https://github.com/grpc/grpc/blob/master/doc/statuscodes.md for detailed
+// See the specification at https://connect.build/docs/protocol for
 // descriptions of each code and example usage.
 type Code uint32
 
 const (
-	// The zero code is OK, which indicates that the operation was a success. We
-	// don't define a constant for it because it overlaps awkwardly with Go's
-	// error semantics: what does it mean to have a non-nil error with an OK
-	// status?
+	// The zero code in gRPC is OK, which indicates that the operation was a
+	// success. We don't define a constant for it because it overlaps awkwardly
+	// with Go's error semantics: what does it mean to have a non-nil error with
+	// an OK status? (Also, the Connect protocol doesn't use a code for
+	// successes.)
 
 	// CodeCanceled indicates that the operation was canceled, typically by the
 	// caller.
-	//
-	// Note that connect follows the gRPC specification (and some, but not all,
-	// implementations) and uses the British "CANCELLED" as CodeCanceled's string
-	// representation rather than the American "CANCELED".
 	CodeCanceled Code = 1
 
 	// CodeUnknown indicates that the operation failed for an unknown reason.
 	CodeUnknown Code = 2
 
 	// CodeInvalidArgument indicates that client supplied an invalid argument.
-	//
-	// Note that this differs from CodeFailedPrecondition: CodeInvalidArgument
-	// indicates that the argument(s) are problematic regardless of the state of
-	// the system (for example, an invalid URL).
 	CodeInvalidArgument Code = 3
 
 	// CodeDeadlineExceeded indicates that deadline expired before the operation
-	// could complete. For operations that change the state of the system, this
-	// error may be returned even if the operation has completed successfully
-	// (but late).
+	// could complete.
 	CodeDeadlineExceeded Code = 4
 
 	// CodeNotFound indicates that some requested entity (for example, a file or
 	// directory) was not found.
-	//
-	// If an operation is denied for an entire class of users, such as gradual
-	// feature rollout or an undocumented allowlist, CodeNotFound may be used. If
-	// a request is denied for some users within a class of users, such as
-	// user-based access control, CodePermissionDenied must be used.
 	CodeNotFound Code = 5
 
 	// CodeAlreadyExists indicates that client attempted to create an entity (for
@@ -73,13 +59,6 @@ const (
 
 	// CodePermissionDenied indicates that the caller does'nt have permission to
 	// execute the specified operation.
-	//
-	// CodePermissionDenied must not be used for rejections caused by exhausting
-	// some resource (use CodeResourceExhausted instead). CodePermissionDenied
-	// must not be used if the caller can't be identified (use
-	// CodeUnauthenticated instead). This error code doesn't imply that the
-	// request is valid, the requested entity exists, or other preconditions are
-	// satisfied.
 	CodePermissionDenied Code = 7
 
 	// CodeResourceExhausted indicates that some resource has been exhausted. For
@@ -89,41 +68,15 @@ const (
 
 	// CodeFailedPrecondition indicates that the system is not in a state
 	// required for the operation's execution.
-	//
-	// Service implementors can use the following guidelines to decide between
-	// CodeFailedPrecondition, CodeAborted, and CodeUnavailable:
-	//
-	//   - Use CodeUnavailable if the client can retry just the failing call.
-	//   - Use CodeAborted if the client should retry at a higher level. For
-	//   example, if a client-specified test-and-set fails, the client should
-	//   restart the whole read-modify-write sequence.
-	//   - Use CodeFailedPrecondition if the client should not retry until the
-	//   system state has been explicitly fixed. For example, a deleting a
-	//   directory on the filesystem might return CodeFailedPrecondition if the
-	//   directory still contains files, since the client should not retry unless
-	//   they first delete the offending files.
 	CodeFailedPrecondition Code = 9
 
 	// CodeAborted indicates that operation was aborted by the system, usually
 	// because of a concurrency issue such as a sequencer check failure or
 	// transaction abort.
-	//
-	// The documentation for CodeFailedPrecondition includes guidelines for
-	// choosing between CodeFailedPrecondition, CodeAborted, and CodeUnavailable.
 	CodeAborted Code = 10
 
 	// CodeOutOfRange indicates that the operation was attempted past the valid
 	// range (for example, seeking past end-of-file).
-	//
-	// Unlike CodeInvalidArgument, this error indicates a problem that may be
-	// fixed if the system state changes. For example, a 32-bit file system will
-	// generate CodeInvalidArgument if asked to read at an offset that is not in
-	// the range [0,2^32), but it will generate CodeOutOfRange if asked to read
-	// from an offset past the current file size.
-	//
-	// CodeOutOfRange naturally overlaps with CodeFailedPrecondition. Where
-	// possible, use the more specific CodeOutOfRange so that callers who are
-	// iterating through a space can easily detect when they're done.
 	CodeOutOfRange Code = 11
 
 	// CodeUnimplemented indicates that the operation isn't implemented,

--- a/codec.go
+++ b/codec.go
@@ -31,18 +31,20 @@ type Codec interface {
 	// Name returns the name of the Codec.
 	//
 	// This may be used as part of the Content-Type within HTTP. For example,
-	// with gRPC this is the content subtype, that is "application/grpc+proto"
-	// will map to the Codec with name "proto".
+	// with gRPC this is the content subtype, so "application/grpc+proto" will
+	// map to the Codec with name "proto".
 	//
-	// Names are expected to not be empty.
+	// Names must not be empty.
 	Name() string
 	// Marshal marshals the given message.
 	//
-	// Marshal may expect a specific type of message, and will error if this type is not given.
+	// Marshal may expect a specific type of message, and will error if this type
+	// is not given.
 	Marshal(any) ([]byte, error)
 	// Marshal unmarshals the given message.
 	//
-	// Unmarshal may expect a specific type of message, and will error if this type is not given.
+	// Unmarshal may expect a specific type of message, and will error if this
+	// type is not given.
 	Unmarshal([]byte, any) error
 }
 

--- a/connect.go
+++ b/connect.go
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 // Package connect is a slim RPC framework built on Protocol Buffers and
-// net/http. In addition to its own protocol, Connect handlers and clients are
-// wire-compatible with gRPC and gRPC-Web, including streaming.
+// net/http. In addition to supporting its own protocol, Connect handlers and
+// clients are wire-compatible with gRPC and gRPC-Web, including streaming.
 //
 // This documentation is intended to explain each type and function in
 // isolation. For walkthroughs, FAQs, and other narrative docs, see
-// https://connect.build.
+// https://connect.build. For a working demonstration service, see
+// https://github.com/bufbuild/connect-demo.
 package connect
 
 import (
@@ -208,8 +209,8 @@ type AnyResponse interface {
 	internalOnly()
 }
 
-// HTTPClient is the transport-level interface connect expects HTTP clients to
-// implement. The standard library's http.Client implements HTTPClient.
+// HTTPClient is the interface connect expects HTTP clients to implement. The
+// standard library's *http.Client implements HTTPClient.
 type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
 }

--- a/connect.go
+++ b/connect.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package connect is an RPC framework built on Protocol Buffers and net/http.
-// It's wire-compatible with gRPC and gRPC-Web, including support for
-// streaming.
+// Package connect is a slim RPC framework built on Protocol Buffers and
+// net/http. In addition to its own protocol, Connect handlers and clients are
+// wire-compatible with gRPC and gRPC-Web, including streaming.
 //
 // This documentation is intended to explain each type and function in
-// isolation. For walkthroughs, comparisons to grpc-go, and other narrative
-// docs, see https://bufconnect.com.
+// isolation. For walkthroughs, FAQs, and other narrative docs, see
+// https://connect.build.
 package connect
 
 import (

--- a/connect.go
+++ b/connect.go
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package connect is a WIP and not ready for consumption.
+// Package connect is an RPC framework built on Protocol Buffers and net/http.
+// It's wire-compatible with gRPC and gRPC-Web, including support for
+// streaming.
+//
+// This documentation is intended to explain each type and function in
+// isolation. For walkthroughs, comparisons to grpc-go, and other narrative
+// docs, see https://bufconnect.com.
 package connect
 
 import (

--- a/error.go
+++ b/error.go
@@ -53,11 +53,10 @@ type ErrorDetail interface {
 // error can't be cast to an *Error, connect will use CodeUnknown and the
 // returned error's message.
 //
-// Error details were introduced before gRPC adopted a formal proposal process,
-// so they're not clearly documented anywhere and may differ slightly between
-// implementations. Roughly, they're an optional mechanism for servers,
-// middleware, and proxies to attach arbitrary Protobuf messages to the error
-// code and message. See https://connect.build/docs/go/errors for more details.
+// Error details are an optional mechanism for servers, interceptors, and
+// proxies to attach arbitrary Protobuf messages to the error code and message.
+// They're a clearer and more performant alternative to HTTP header
+// microformats. See https://connect.build/docs/go/errors for more details.
 type Error struct {
 	code    Code
 	err     error
@@ -78,10 +77,8 @@ func (e *Error) Error() string {
 	return e.code.String() + ": " + message
 }
 
-// Message returns the underlying error message.
-//
-// This may be empty if the original error was composed with a status
-// code and a nil error.
+// Message returns the underlying error message. It may be empty if the
+// original error was created with a status code and a nil error.
 func (e *Error) Message() string {
 	if e.err != nil {
 		return e.err.Error()

--- a/error.go
+++ b/error.go
@@ -41,12 +41,12 @@ type ErrorDetail interface {
 	UnmarshalTo(proto.Message) error
 }
 
-// An Error captures three key pieces of information: a Code, an underlying Go
-// error, and an optional collection of arbitrary Protobuf messages called
-// "details" (more on those below). Servers send the code, the underlying
-// error's Error() output, and details over the wire to clients. Remember that
-// the underlying error's message will be sent to clients - take care not to
-// leak sensitive information from public APIs!
+// An Error captures four key pieces of information: a Code, an underlying Go
+// error, a map of metadata, and an optional collection of arbitrary Protobuf
+// messages called "details" (more on those below). Servers send the code, the
+// underlying error's Error() output, the metadata, and details over the wire
+// to clients. Remember that the underlying error's message will be sent to
+// clients - take care not to leak sensitive information from public APIs!
 //
 // Service implementations and interceptors should return errors that can be
 // cast to an *Error (using the standard library's errors.As). If the returned
@@ -57,7 +57,7 @@ type ErrorDetail interface {
 // so they're not clearly documented anywhere and may differ slightly between
 // implementations. Roughly, they're an optional mechanism for servers,
 // middleware, and proxies to attach arbitrary Protobuf messages to the error
-// code and message.
+// code and message. See https://connect.build/docs/go/errors for more details.
 type Error struct {
 	code    Code
 	err     error

--- a/handler_example_test.go
+++ b/handler_example_test.go
@@ -17,7 +17,6 @@ package connect_test
 import (
 	"context"
 	"net/http"
-	"time"
 
 	"github.com/bufbuild/connect-go"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
@@ -44,10 +43,6 @@ func (*ExamplePingServer) Ping(
 }
 
 func Example_handler() {
-	// The business logic here is trivial, but the rest of the example is meant
-	// to be somewhat realistic. This server has basic timeouts configured, and
-	// it also exposes gRPC's server reflection and health check APIs.
-
 	// protoc-gen-connect-go generates constructors that return plain net/http
 	// Handlers, so they're compatible with most Go HTTP routers and middleware
 	// (for example, net/http's StripPrefix). Each handler automatically supports
@@ -59,24 +54,18 @@ func Example_handler() {
 		),
 	)
 	// You can serve gRPC's health and server reflection APIs using
-	// github.com/bufbuild/connect-grpchealth-go and github.com/bufbuild/connect-grpcreflect-go.
-
-	// Timeouts, connection handling, TLS configuration, and other low-level
-	// transport details are handled by net/http. Everything you already know (or
-	// anything you learn) about hardening net/http Servers applies to connect
-	// too. Keep in mind that any timeouts you set will also apply to streaming
-	// RPCs!
-	//
-	// If you're not familiar with the many timeouts exposed by net/http, start with
-	// https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/.
-	server := &http.Server{
-		Addr:           ":http",
-		Handler:        mux,
-		ReadTimeout:    2500 * time.Millisecond,
-		WriteTimeout:   5 * time.Second,
-		MaxHeaderBytes: 8 * 1024, // 8KiB, gRPC's recommendation
-	}
-	// You could also use golang.org/x/net/http2/h2c to serve gRPC requests
-	// without TLS.
-	_ = server.ListenAndServeTLS("internal/testdata/server.crt", "internal/testdata/server.key")
+	// github.com/bufbuild/connect-grpchealth-go and
+	// github.com/bufbuild/connect-grpcreflect-go.
+	_ = http.ListenAndServeTLS(
+		"localhost:8080",
+		"internal/testdata/server.crt",
+		"internal/testdata/server.key",
+		mux,
+	)
+	// To serve HTTP/2 requests without TLS (as many gRPC clients expect), import
+	// golang.org/x/net/http2/h2c and golang.org/x/net/http2 and change to:
+	// _ = http.ListenAndServe(
+	// 	"localhost:8080",
+	// 	h2c.NewHandler(mux, &http2.Server{}),
+	// )
 }

--- a/header.go
+++ b/header.go
@@ -29,7 +29,9 @@ func EncodeBinaryHeader(data []byte) string {
 }
 
 // DecodeBinaryHeader base64-decodes the data. It can decode padded or unpadded
-// values.
+// values. Following usual HTTP semantics, multiple base64-encoded values may
+// be joined with a comma. When receiving such comma-separated values, split
+// them with strings.Split before calling DecodeBinaryHeader.
 //
 // Binary headers sent using the Connect, gRPC, and gRPC-Web protocols have
 // keys ending in "-Bin".

--- a/interceptor.go
+++ b/interceptor.go
@@ -21,7 +21,7 @@ import (
 // UnaryFunc is the generic signature of a unary RPC. Interceptors wrap Funcs.
 //
 // The type of the request and response structs depend on the codec being used.
-// When using protobuf, request.Any() and response.Any() will always be
+// When using Protobuf, request.Any() and response.Any() will always be
 // proto.Message implementations.
 type UnaryFunc func(context.Context, AnyRequest) (AnyResponse, error)
 

--- a/interceptor_example_test.go
+++ b/interceptor_example_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
 )
 
-func ExampleInterceptor() {
+func ExampleUnaryInterceptorFunc() {
 	logger := log.New(os.Stdout, "" /* prefix */, 0 /* flags */)
 	loggingInterceptor := connect.UnaryInterceptorFunc(
 		func(next connect.UnaryFunc) connect.UnaryFunc {

--- a/option.go
+++ b/option.go
@@ -140,7 +140,10 @@ type Option interface {
 // google.golang.org/protobuf/proto. Handlers also support JSON by default,
 // using the standard Protobuf JSON mapping. Users with more specialized needs
 // may override the default codecs by registering a new codec under the "proto"
-// or "json" names.
+// or "json" names. When supplying a custom "proto" codec, keep in mind that
+// some unexported, protocol-specific messages are serialized using Protobuf -
+// take care to fall back to the standard Protobuf implementation if
+// necessary.
 //
 // Registering a codec with an empty name is a no-op.
 func WithCodec(codec Codec) Option {

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -225,6 +225,10 @@ func (c *connectClient) WriteRequestHeader(streamType StreamType, header http.He
 	}
 	acceptCompressionHeader := connectUnaryHeaderAcceptCompression
 	if streamType != StreamTypeUnary {
+		// If we don't set Accept-Encoding, by default http.Client will ask the
+		// server to compress the whole stream. Since we're already compressing
+		// each message, this is a waste.
+		header[connectUnaryHeaderAcceptCompression] = []string{compressionIdentity}
 		acceptCompressionHeader = connectStreamingHeaderAcceptCompression
 		// We only write the request encoding header here for streaming calls,
 		// since the streaming envelope lets us choose whether to compress each

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -191,6 +191,10 @@ func (g *grpcClient) WriteRequestHeader(_ StreamType, header http.Header) {
 	// checks in Header.Set.
 	header[headerUserAgent] = []string{grpcUserAgent()}
 	header[headerContentType] = []string{grpcContentTypeFromCodecName(g.web, g.Codec.Name())}
+	// gRPC handles compression on a per-message basis, so we don't want to
+	// compress the whole stream. By default, http.Client will ask the server
+	// to gzip the stream if we don't set Accept-Encoding.
+	header["Accept-Encoding"] = []string{compressionIdentity}
 	if g.CompressionName != "" && g.CompressionName != compressionIdentity {
 		header[grpcHeaderCompression] = []string{g.CompressionName}
 	}


### PR DESCRIPTION
- Disable automatic client compression where appropriate
- Add GoDoc for binary header splitting
- Update Error GoDoc for metadata
- Revert "Mark repository as a work in progress"
- Reword README to match connect.build
- Simplify examples
- Polish GoDoc a bit more
