### PR TITLE
Add automated release notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: Enhancements
+      labels:
+        - enhancement
+    - title: Bugfixes
+      labels:
+        - bug
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
It's hard to test, but I _think_ that this config will get us reasonable
release notes without any manual work.

https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
