### PR TITLE
WithInterceptors: Improve ASCII diagram

### DIFF
--- a/option.go
+++ b/option.go
@@ -177,30 +177,32 @@ func WithCompressMinBytes(min int) Option {
 //
 // Applied to client and handler, WithInterceptors(A, B, ..., Y, Z) produces:
 //
-//        client.Send()     client.Receive()
-//              |                 ^
-//              v                 |
-//           A ---               --- A
-//           B ---               --- B
-//             ...               ...
-//           Y ---               --- Y
-//           Z ---               --- Z
-//              |                 ^
-//              v                 |
-//           network            network
-//              |                 ^
-//              v                 |
-//           A ---               --- A
-//           B ---               --- B
-//             ...               ...
-//           Y ---               --- Y
-//           Z ---               --- Z
-//              |                 ^
-//              v                 |
-//       handler.Receive() handler.Send()
-//              |                 ^
-//              |                 |
-//              -> handler logic --
+//      client.Send()       client.Receive()
+//            |                   ^
+//            v                   |
+//         A ---                 --- A
+//         B ---                 --- B
+//         : ...                 ... :
+//         Y ---                 --- Y
+//         Z ---                 --- Z
+//            |                   ^
+//            v                   |
+//       = = = = = = = = = = = = = = = =
+//                    network
+//       = = = = = = = = = = = = = = = =
+//            |                   ^
+//            v                   |
+//         A ---                 --- A
+//         B ---                 --- B
+//         : ...                 ... :
+//         Y ---                 --- Y
+//         Z ---                 --- Z
+//            |                   ^
+//            v                   |
+//     handler.Receive()   handler.Send()
+//            |                   ^
+//            |                   |
+//            '-> handler logic >-'
 //
 // Note that in clients, the Sender handles the request message(s) and the
 // Receiver handles the response message(s). For handlers, it's the reverse.


### PR DESCRIPTION
I felt that the diagram demonstrating the flow of information across
server interceptors, the network, and client interceptors could be more
readable.

This makes the following changes to it:

- Use ":" as a vertical ellipsis for "A B ... Y Z"
- Turn the network entries into a single delimited layer that the
  requests pass through
- Curve the lines at edges with `'` instead of `|` and `-`
- Increase distance between left and right sides by two more spaces
- Add arrow end/start around "handler logic"