### PR TITLE
Fixed README examples; Set autogeneration of them using mdox tool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lintfix: $(BIN)/golangci-lint $(BIN)/buf ## Automatically fix some lint errors
 	$(BIN)/buf format -w .
 
 .PHONY: generate
-generate: $(BIN)/buf $(BIN)/protoc-gen-go $(BIN)/protoc-gen-connect-go $(BIN)/license-header ## Regenerate code and licenses
+generate: $(BIN)/buf $(BIN)/protoc-gen-go $(BIN)/protoc-gen-connect-go $(BIN)/license-header $(BIN)/mdox ## Regenerate code, examples and licenses
 	rm -rf internal/gen
 	PATH=$(BIN) $(BIN)/buf generate
 	@# We want to operate on a list of modified and new files, excluding
@@ -67,6 +67,8 @@ generate: $(BIN)/buf $(BIN)/protoc-gen-go $(BIN)/protoc-gen-connect-go $(BIN)/li
 			--license-type apache \
 			--copyright-holder "Buf Technologies, Inc." \
 			--year-range "$(COPYRIGHT_YEARS)"
+	@# README auto-generates examples
+	$(BIN)/mdox fmt -l *.md
 
 .PHONY: upgrade
 upgrade: ## Upgrade dependencies
@@ -94,6 +96,10 @@ $(BIN)/license-header: Makefile
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+
+$(BIN)/mdox: Makefile
+	@mkdir -p $(@D)
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/bwplotka/mdox@v0.9.0
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,10 @@
-Connect
-=======
+# Connect
 
-[![Build](https://github.com/bufbuild/connect-go/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/bufbuild/connect-go/actions/workflows/ci.yaml)
-[![Report Card](https://goreportcard.com/badge/github.com/bufbuild/connect-go)](https://goreportcard.com/report/github.com/bufbuild/connect-go)
-[![GoDoc](https://pkg.go.dev/badge/github.com/bufbuild/connect-go.svg)](https://pkg.go.dev/github.com/bufbuild/connect-go)
+[![Build](https://github.com/bufbuild/connect-go/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/bufbuild/connect-go/actions/workflows/ci.yaml) [![Report Card](https://goreportcard.com/badge/github.com/bufbuild/connect-go)](https://goreportcard.com/report/github.com/bufbuild/connect-go) [![GoDoc](https://pkg.go.dev/badge/github.com/bufbuild/connect-go.svg)](https://pkg.go.dev/github.com/bufbuild/connect-go)
 
-Connect is a slim library for building browser and gRPC-compatible HTTP APIs.
-You write a short [Protocol Buffer][protobuf] schema and implement your
-application logic, and Connect generates code to handle marshaling, routing,
-compression, and content type negotiation. It also generates an idiomatic,
-type-safe client. Handlers and clients support three protocols: gRPC, gRPC-Web,
-and Connect's own protocol.
+Connect is a slim library for building browser and gRPC-compatible HTTP APIs. You write a short [Protocol Buffer](https://developers.google.com/protocol-buffers) schema and implement your application logic, and Connect generates code to handle marshaling, routing, compression, and content type negotiation. It also generates an idiomatic, type-safe client. Handlers and clients support three protocols: gRPC, gRPC-Web, and Connect's own protocol.
 
-The [Connect protocol][protocol] is a simple, POST-only protocol that works
-over HTTP/1.1 or HTTP/2. It takes the best portions of gRPC and gRPC-Web,
-including streaming, and packages them into a protocol that works equally well
-in browsers, monoliths, and microservices. Calling a Connect API is as easy as
-using `curl`. Try it with our live demo:
+The [Connect protocol](https://connect.build/docs/protocol) is a simple, POST-only protocol that works over HTTP/1.1 or HTTP/2. It takes the best portions of gRPC and gRPC-Web, including streaming, and packages them into a protocol that works equally well in browsers, monoliths, and microservices. Calling to Connect API is as easy as using `curl`. Try it with our live demo:
 
 ```
 curl \
@@ -25,10 +13,7 @@ curl \
     https://demo.connect.build/buf.connect.demo.eliza.v1.ElizaService/Say
 ```
 
-Handlers and clients also support the gRPC and gRPC-Web protocols, including
-streaming, headers, trailers, and error details. gRPC-compatible [server
-reflection][] and [health checks][] are available as standalone packages.
-Instead of cURL, we could call our API with `grpcurl`:
+Handlers and clients also support the gRPC and gRPC-Web protocols, including streaming, headers, trailers, and error details. gRPC-compatible [server reflection](https://github.com/bufbuild/connect-grpcreflect-go) and [health checks](https://github.com/bufbuild/connect-grpchealth-go) are available as standalone packages. Instead of cURL, we could call our API with `grpcurl`:
 
 ```
 go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
@@ -38,151 +23,163 @@ grpcurl \
     buf.connect.demo.eliza.v1.ElizaService/Say
 ```
 
-Under the hood, Connect is just [Protocol Buffers][protobuf] and the standard
-library: no custom HTTP implementation, no new name resolution or load
-balancing APIs, and no surprises. Everything you already know about `net/http`
-still applies, and any package that works with an `http.Server`, `http.Client`,
-or `http.Handler` also works with Connect.
+Under the hood, Connect is just [Protocol Buffers](https://developers.google.com/protocol-buffers) and the standard library: no custom HTTP implementation, no new name resolution or load balancing APIs, and no surprises. Everything you already know about `net/http` still applies, and any package that works with an `http.Server`, `http.Client`, or `http.Handler` also works with Connect.
 
-For more on Connect, see the [announcement blog post][blog], the documentation
-on [connect.build][docs] (especially the [Getting Started] guide for Go), the
-[demo service][demo], or the [protocol specification][protocol].
+For more on Connect, see the [announcement blog post](https://buf.build/blog/connect-a-better-grpc), the documentation on [connect.build](https://connect.build) (especially the [Getting Started](https://connect.build/docs/go/getting-started) guide for Go), the [demo service](https://github.com/bufbuild/connect-demo), or the [protocol specification](https://connect.build/docs/protocol).
 
 ## A small example
 
-Curious what all this looks like in practice? From a [Protobuf
-schema](internal/proto/connect/ping/v1/ping.proto), we generate [a small RPC
-package](internal/gen/connect/ping/v1/pingv1connect/ping.connect.go). Using that
-package, we can build a server:
+Curious what all this looks like in practice? From a [Protobuf schema](internal/proto/connect/ping/v1/ping.proto), we generate [a small RPC package](internal/gen/connect/ping/v1/pingv1connect/ping.connect.go). Using that package, we can build a [server](examples/ping/server/server.go):
 
-```go
+```go mdox-exec="sed -n '15,69p' examples/ping/server/server.go"
 package main
 
 import (
-  "log"
-  "net/http"
+	"context"
+	"log"
+	"net/http"
 
-  "github.com/bufbuild/connect-go"
-  "github.com/bufbuild/connect-go/internal/gen/connect/connect/ping/v1/pingv1connect"
-  pingv1 "github.com/bufbuild/connect-go/internal/gen/go/connect/ping/v1"
-  "golang.org/x/net/http2"
-  "golang.org/x/net/http2/h2c"
+	"github.com/bufbuild/connect-go"
+	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
+	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 type PingServer struct {
-  pingv1connect.UnimplementedPingServiceHandler // returns errors from all methods
+	// Returns errors from all methods we don't want to implement for now.
+	pingv1connect.UnimplementedPingServiceHandler
 }
 
 func (ps *PingServer) Ping(
-  ctx context.Context,
-  req *connect.Request[pingv1.PingRequest],
+	_ context.Context,
+	req *connect.Request[pingv1.PingRequest],
 ) (*connect.Response[pingv1.PingResponse], error) {
-  // connect.Request and connect.Response give you direct access to headers and
-  // trailers. No context-based nonsense!
-  log.Println(req.Header().Get("Some-Header"))
-  res := connect.NewResponse(&pingv1.PingResponse{
-    // req.Msg is a strongly-typed *pingv1.PingRequest, so we can access its
-    // fields without type assertions.
-    Number: req.Msg.Number,
-  })
-  res.Header().Set("Some-Other-Header", "hello!")
-  return res, nil
+
+	// Finally `connect.Request` behaves like standard HTTP library.
+	// For example, it gives you direct access to headers and trailers.
+	log.Println("Request header:", req.Header().Get("Some-Header"))
+
+	// The request for this method is a strongly-typed as defined by *pingv1.PingRequest,
+	// so we can access for example `Msg` field safely!
+	res := connect.NewResponse(&pingv1.PingResponse{Number: req.Msg.Number})
+
+	// Similarly we can add extra headers to response.
+	res.Header().Set("Some-Other-Header", "hello!")
+
+	// Just return response or error like you would do in non-remote Go method!
+	return res, nil
 }
 
 func main() {
-  mux := http.NewServeMux()
-  // The generated constructors return a path and a plain net/http
-  // handler.
-  mux.Handle(pingv1.NewPingServiceHandler(&PingServer{}))
-  http.ListenAndServe(
-    "localhost:8080",
-    // For gRPC clients, it's convenient to support HTTP/2 without TLS. You can
-    // avoid x/net/http2 by using http.ListenAndServeTLS.
-    h2c.NewHandler(mux, &http2.Server{}),
-  )
+	// Standard mux for handlers.
+	mux := http.NewServeMux()
+
+	// Register handlers for gRPC connect ping service we implemented above.
+	mux.Handle(pingv1connect.NewPingServiceHandler(&PingServer{}))
+
+	log.Println("Starting server that accepts both Connect enabled HTTP Post, gRPC and gRPC-Web!")
+	if err := http.ListenAndServe(
+		"localhost:8080",
+		// For the example gRPC clients, it's convenient to support HTTP/2 without TLS.
+		h2c.NewHandler(mux, &http2.Server{}),
+	); err != nil {
+		log.Fatal(err)
+	}
 }
 ```
 
-With that server running, you can make requests with any gRPC or Connect
-client. To write a client using `connect-go`,
+With that server running, you can make requests with any HTTP (post), gRPC or Connect client. For example, we could use `curl`:
 
-```go
+```bash
+curl --header "Content-Type: application/json" --data '{"number": 5}' http://localhost:8080/connect.ping.v1.PingService/Ping
+```
+
+We can also craft a type-safe HTTP client in Go. See [client](examples/ping/http/client.go) using `connect-go` below:
+
+```go mdox-exec="sed -n '15,62p' examples/ping/http/client.go"
 package main
 
 import (
-  "log"
-  "net/http"
+	"context"
+	"crypto/tls"
+	"log"
+	"net"
+	"net/http"
 
-  "github.com/bufbuild/connect-go"
-  "github.com/bufbuild/connect-go/internal/gen/connect/connect/ping/v1/pingv1connect"
-  pingv1 "github.com/bufbuild/connect-go/internal/gen/go/connect/ping/v1"
+	"github.com/bufbuild/connect-go"
+	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
+	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
+	"golang.org/x/net/http2"
 )
 
+func newInsecureHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true, // Permits HTTP/2 requests using the insecure.
+			DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+		},
+	}
+}
+
 func main() {
-  client, err := pingv1connect.NewPingServiceClient(
-    http.DefaultClient,
-    "https://localhost:8080/",
-  )
-  if err != nil {
-    log.Fatalln(err)
-  }
-  req := connect.NewRequest(&pingv1.PingRequest{
-    Number: 42,
-  })
-  req.Header().Set("Some-Header", "hello from connect")
-  res, err := client.Ping(context.Background(), req)
-  if err != nil {
-    log.Fatalln(err)
-  }
-  log.Println(res.Msg)
-  log.Println(res.Header().Get("Some-Other-Header"))
+	// Create client.
+	client := pingv1connect.NewPingServiceClient(
+		newInsecureHTTPClient(),
+		"https://localhost:8080/",
+	)
+
+	// Create request with type-safe payload and extra header.
+	req := connect.NewRequest(&pingv1.PingRequest{Number: 42})
+	req.Header().Set("Some-Header", "Hello from connect! 💪")
+
+	// Call remote gRPC server.
+	res, err := client.Ping(context.Background(), req)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Enjoy the type-safe response!
+	log.Println(res.Msg)
+	log.Println("Response header:", res.Header().Get("Some-Other-Header"))
 }
 ```
 
-Of course, `http.ListenAndServe` and `http.DefaultClient` aren't fit for
-production use! See Connect's [deployment docs][docs-deployment] for a guide to
-configuring timeouts, connection pools, observability, and h2c.
+To force client to use gRPC instead of HTTP it's as easy as adding `connect.WithGRPC`. See a snippet from the [client](examples/ping/grpc/client.go):
+
+```go mdox-exec="sed -n '42,47p' examples/ping/grpc/client.go"
+	// Create client.
+	client := pingv1connect.NewPingServiceClient(
+		newInsecureHTTPClient(),
+		"https://localhost:8080/",
+		connect.WithGRPC(), // Force using gRPC instead of HTTP (post).
+	)
+```
+
+Of course, as with standard HTTP server, default configurations of `http.ListenAndServe` and `http.DefaultClient` are not what you should run on production. See Connect's recommended options in [deployment docs](https://connect.build/docs/go/deployment). It guides you through suggested timeouts, connection pools, observability, and h2c.
 
 ## Ecosystem
 
-* [connect-grpchealth-go]: gRPC-compatible health checks
-* [connect-grpcreflect-go]: gRPC-compatible server reflection
-* [connect-demo]: demonstration service powering demo.connect.build, including bidi streaming
-* [connect-crosstest]: gRPC and gRPC-Web interoperability tests
+* [connect-grpchealth-go](https://github.com/bufbuild/connect-grpchealth-go): gRPC-compatible health checks
+* [connect-grpcreflect-go](https://github.com/bufbuild/connect-grpcreflect-go): gRPC-compatible server reflection
+* [connect-demo](https://github.com/bufbuild/connect-demo): demonstration service powering demo.connect.build, including bidi streaming
+* [connect-crosstest](https://github.com/bufbuild/connect-crosstest): gRPC and gRPC-Web interoperability tests
 
 ## Status
 
-This module is a beta: we rely on it in production, but we may make a few
-changes as we gather feedback from early adopters. We're planning to tag a
-stable v1 in October, soon after the Go 1.19 release.
+This module is a beta: we rely on it in production, but we may make a few changes as we gather feedback from early adopters. We're planning to tag a stable v1 in October, soon after the Go 1.19 release.
 
 ## Support and versioning
 
 `connect-go` supports:
 
-* The [two most recent major releases][go-support-policy] of Go, with a minimum
-  of Go 1.18.
-* [APIv2] of Protocol Buffers in Go (`google.golang.org/protobuf`).
+* The [two most recent major releases](https://golang.org/doc/devel/release#policy) of Go, with a minimum of Go 1.18.
+* [APIv2](https://blog.golang.org/protobuf-apiv2) of Protocol Buffers in Go (`google.golang.org/protobuf`).
 
 Within those parameters, Connect follows semantic versioning.
 
 ## Legal
 
-Offered under the [Apache 2 license][license].
-
-[APIv2]: https://blog.golang.org/protobuf-apiv2
-[Getting Started]: https://connect.build/docs/go/getting-started
-[blog]: https://buf.build/blog/connect-a-better-grpc
-[connect-grpchealth-go]: https://github.com/bufbuild/connect-grpchealth-go
-[connect-grpcreflect-go]: https://github.com/bufbuild/connect-grpcreflect-go
-[connect-demo]: https://github.com/bufbuild/connect-demo
-[connect-crosstest]: https://github.com/bufbuild/connect-crosstest
-[demo]: https://github.com/bufbuild/connect-demo
-[docs]: https://connect.build
-[docs-deployment]: https://connect.build/docs/go/deployment
-[go-support-policy]: https://golang.org/doc/devel/release#policy
-[license]: https://github.com/bufbuild/connect-go/blob/main/LICENSE
-[protobuf]: https://developers.google.com/protocol-buffers
-[protocol]: https://connect.build/docs/protocol
-[server reflection]: https://github.com/bufbuild/connect-grpcreflect-go
-[health checks]: https://github.com/bufbuild/connect-grpchealth-go
+Offered under the [Apache 2 license](https://github.com/bufbuild/connect-go/blob/main/LICENSE).

--- a/examples/ping/grpc/client.go
+++ b/examples/ping/grpc/client.go
@@ -1,0 +1,62 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/bufbuild/connect-go"
+	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
+	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
+	"golang.org/x/net/http2"
+)
+
+func newInsecureHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true, // Permits HTTP/2 requests using the insecure.
+			DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+		},
+	}
+}
+
+func main() {
+	// Create client.
+	client := pingv1connect.NewPingServiceClient(
+		newInsecureHTTPClient(),
+		"https://localhost:8080/",
+		connect.WithGRPC(), // Force using gRPC instead of HTTP (post).
+	)
+
+	// Create request with type-safe payload and extra header.
+	req := connect.NewRequest(&pingv1.PingRequest{Number: 42})
+	req.Header().Set("Some-Header", "Hello from connect! 💪")
+
+	// Call remote gRPC server.
+	res, err := client.Ping(context.Background(), req)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Enjoy the type-safe response!
+	log.Println(res.Msg)
+	log.Println("Response header:", res.Header().Get("Some-Other-Header"))
+}

--- a/examples/ping/http/client.go
+++ b/examples/ping/http/client.go
@@ -1,0 +1,61 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/bufbuild/connect-go"
+	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
+	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
+	"golang.org/x/net/http2"
+)
+
+func newInsecureHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true, // Permits HTTP/2 requests using the insecure.
+			DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+		},
+	}
+}
+
+func main() {
+	// Create client.
+	client := pingv1connect.NewPingServiceClient(
+		newInsecureHTTPClient(),
+		"https://localhost:8080/",
+	)
+
+	// Create request with type-safe payload and extra header.
+	req := connect.NewRequest(&pingv1.PingRequest{Number: 42})
+	req.Header().Set("Some-Header", "Hello from connect! 💪")
+
+	// Call remote gRPC server.
+	res, err := client.Ping(context.Background(), req)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Enjoy the type-safe response!
+	log.Println(res.Msg)
+	log.Println("Response header:", res.Header().Get("Some-Other-Header"))
+}

--- a/examples/ping/server/server.go
+++ b/examples/ping/server/server.go
@@ -1,0 +1,69 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/bufbuild/connect-go"
+	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
+	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+type PingServer struct {
+	// Returns errors from all methods we don't want to implement for now.
+	pingv1connect.UnimplementedPingServiceHandler
+}
+
+func (ps *PingServer) Ping(
+	_ context.Context,
+	req *connect.Request[pingv1.PingRequest],
+) (*connect.Response[pingv1.PingResponse], error) {
+
+	// Finally `connect.Request` behaves like standard HTTP library.
+	// For example, it gives you direct access to headers and trailers.
+	log.Println("Request header:", req.Header().Get("Some-Header"))
+
+	// The request for this method is a strongly-typed as defined by *pingv1.PingRequest,
+	// so we can access for example `Msg` field safely!
+	res := connect.NewResponse(&pingv1.PingResponse{Number: req.Msg.Number})
+
+	// Similarly we can add extra headers to response.
+	res.Header().Set("Some-Other-Header", "hello!")
+
+	// Just return response or error like you would do in non-remote Go method!
+	return res, nil
+}
+
+func main() {
+	// Standard mux for handlers.
+	mux := http.NewServeMux()
+
+	// Register handlers for gRPC connect ping service we implemented above.
+	mux.Handle(pingv1connect.NewPingServiceHandler(&PingServer{}))
+
+	log.Println("Starting server that accepts both Connect enabled HTTP Post, gRPC and gRPC-Web!")
+	if err := http.ListenAndServe(
+		"localhost:8080",
+		// For the example gRPC clients, it's convenient to support HTTP/2 without TLS.
+		h2c.NewHandler(mux, &http2.Server{}),
+	); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,8 @@ go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.8
+	golang.org/x/net v0.0.0-20220531201128-c960675eff93
 	google.golang.org/protobuf v1.28.0
 )
+
+require golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/net v0.0.0-20220531201128-c960675eff93 h1:MYimHLfoXEpOhqd/zgoA/uoXzHB86AEky4LAx5ij9xA=
+golang.org/x/net v0.0.0-20220531201128-c960675eff93/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=


### PR DESCRIPTION
Hey!

Huge fan here, this project is amazing! 💪🏽  It has lots of features (3 protocols in one), so I think examples has to be clear. I found the existing ones obsolete so I recreated them and committed with tooling that autogenerates them in README once changed. 

`make test` also checks if the examples are buildable, which will keep them up-to-date! 

Hopefully that will help make this project more accessible, cheers. Keep the good work!

I hope you don't mind putting auto-formatter for README. It ensures consistency and e.g puts all on single line (all IDEs handle that just fine, so no point in trying to manually adjust width of text)

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>