### PR TITLE
Stencil fewer functions

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -225,28 +225,6 @@ type Spec struct {
 	IsClient   bool   // otherwise we're in a handler
 }
 
-// receiveUnaryRequest unmarshals a message from a Receiver, then envelopes
-// the message and attaches the Receiver's headers and RPC specification.
-func receiveUnaryRequest[T any](receiver Receiver) (*Request[T], error) {
-	var msg T
-	if err := receiver.Receive(&msg); err != nil {
-		return nil, err
-	}
-	return &Request[T]{
-		Msg:    &msg,
-		spec:   receiver.Spec(),
-		header: receiver.Header(),
-	}, nil
-}
-
-func receiveUnaryRequestMetadata[T any](r Receiver) *Request[T] {
-	return &Request[T]{
-		Msg:    new(T),
-		spec:   r.Spec(),
-		header: r.Header(),
-	}
-}
-
 // receiveUnaryResponse unmarshals a message from a Receiver, then envelopes
 // the message and attaches the Receiver's headers and trailers. It attempts to
 // consume the Receiver and isn't appropriate when receiving multiple messages.


### PR DESCRIPTION
We're currently using two generic functions to unmarshal unary requests
from Receivers. Because the two functions must use structs as their type
parameters (and structs have different gcshapes), we're stenciling a new
version of each function for each unary RPC.

These functions aren't complex enough to warrant this binary bloat. It's
simple enough to inline the logic where we use it instead.

(I don't think we need to be paranoid about this category of problems,
though - the Go generics implementation will almost certainly get better
over the next few releases, so it's not worth contorting our code to
work around imperfections in 1.18.)
