### PR TITLE
Delete "Anything Else" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/anything_else.md
+++ b/.github/ISSUE_TEMPLATE/anything_else.md
@@ -1,7 +1,0 @@
----
-name: Anything else
-about: File any other type of issue
-title: ''
-assignees: ''
-
----


### PR DESCRIPTION
When you go to create a new issue, it effectively has an "anything else" link built in.