### PR TITLE
Remove comment after "behavior change" in grpc-go

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -218,8 +218,6 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 
 	// The gRPC-HTTP2, gRPC-Web, and Connect protocols are all POST-only.
 	if request.Method != http.MethodPost {
-		// grpc-go returns a 500 here, but interoperability with non-gRPC HTTP
-		// clients is better if we return a 405.
 		responseWriter.Header().Set("Allow", http.MethodPost)
 		responseWriter.WriteHeader(http.StatusMethodNotAllowed)
 		return


### PR DESCRIPTION
gRPC-Go has decided to care about normal HTTP semantics and changed this
behavior in a [minor release](https://github.com/grpc/grpc-go/releases/tag/v1.47.0). We can delete our explanatory comment now.