### PR TITLE
fix minCode constant

### DIFF
--- a/code.go
+++ b/code.go
@@ -57,7 +57,7 @@ const (
 	// example, a file or directory) that already exists.
 	CodeAlreadyExists Code = 6
 
-	// CodePermissionDenied indicates that the caller does'nt have permission to
+	// CodePermissionDenied indicates that the caller doesn't have permission to
 	// execute the specified operation.
 	CodePermissionDenied Code = 7
 
@@ -100,8 +100,8 @@ const (
 	// authentication credentials for the operation.
 	CodeUnauthenticated Code = 16
 
-	minCode Code = CodeUnknown
-	maxCode Code = CodeUnauthenticated
+	minCode = CodeCanceled
+	maxCode = CodeUnauthenticated
 )
 
 func (c Code) String() string {

--- a/code_test.go
+++ b/code_test.go
@@ -15,6 +15,7 @@
 package connect
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -38,6 +39,8 @@ func TestCode(t *testing.T) {
 		assertCodeRoundTrips(t, code)
 	}
 	assertCodeRoundTrips(t, Code(999))
+	var canceledInvalid Code
+	assert.NotNil(t, canceledInvalid.UnmarshalText([]byte("code_"+strconv.Itoa(int(CodeCanceled)))))
 }
 
 func assertCodeRoundTrips(tb testing.TB, code Code) {
@@ -47,4 +50,8 @@ func assertCodeRoundTrips(tb testing.TB, code Code) {
 	var decoded Code
 	assert.Nil(tb, decoded.UnmarshalText(encoded))
 	assert.Equal(tb, decoded, code)
+	if code >= minCode && code <= maxCode {
+		var invalid Code
+		assert.NotNil(tb, invalid.UnmarshalText([]byte("code_"+strconv.Itoa(int(code)))))
+	}
 }

--- a/code_test.go
+++ b/code_test.go
@@ -39,8 +39,6 @@ func TestCode(t *testing.T) {
 		assertCodeRoundTrips(t, code)
 	}
 	assertCodeRoundTrips(t, Code(999))
-	var canceledInvalid Code
-	assert.NotNil(t, canceledInvalid.UnmarshalText([]byte("code_"+strconv.Itoa(int(CodeCanceled)))))
 }
 
 func assertCodeRoundTrips(tb testing.TB, code Code) {
@@ -52,6 +50,7 @@ func assertCodeRoundTrips(tb testing.TB, code Code) {
 	assert.Equal(tb, decoded, code)
 	if code >= minCode && code <= maxCode {
 		var invalid Code
+		// For the known codes, we only accept the canonical string representation: "canceled", not "code_1".
 		assert.NotNil(tb, invalid.UnmarshalText([]byte("code_"+strconv.Itoa(int(code)))))
 	}
 }


### PR DESCRIPTION
The minCode constant should be set to CodeCanceled, not CodeUnknown. Add
test coverage to ensure that known codes don't unmarshal when using
"code_<num>" encoding.

**Before submitting your PR:** Please read through the contribution guide at https://github.com/bufbuild/connect-go/blob/main/.github/CONTRIBUTING.md
