### PR TITLE
ensure consistent nil response handling

### DIFF
--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -151,7 +151,7 @@ func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 		return 0, wrapIfContextError(err)
 	}
 	if d.response == nil {
-		return 0, io.EOF
+		return 0, fmt.Errorf("nil response from %v", d.request.URL)
 	}
 	return d.response.Body.Read(data)
 }


### PR DESCRIPTION
Update duplex_http_call to handle a nil response in the Read() and
ResponseStatusCode methods for consistency with other methods. Change
the signature of `ResponseStatusCode` to return an error if the returned
response is nil.

**Before submitting your PR:** Please read through the contribution guide at https://github.com/bufbuild/connect-go/blob/main/.github/CONTRIBUTING.md
