### PR TITLE
Fix Connect header constant

### DIFF
--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -34,7 +34,7 @@ const (
 	connectUnaryHeaderCompression           = "Content-Encoding"
 	connectUnaryHeaderAcceptCompression     = "Accept-Encoding"
 	connectUnaryTrailerPrefix               = "Trailer-"
-	connectStreamingHeaderCompression       = "Connect-Encoding"
+	connectStreamingHeaderCompression       = "Connect-Content-Encoding"
 	connectStreamingHeaderAcceptCompression = "Connect-Accept-Encoding"
 	connectHeaderTimeout                    = "Connect-Timeout-Ms"
 


### PR DESCRIPTION
Yikes! [Per the specification](https://connect.build/docs/protocol#streaming-request), we should be using `Connect-Content-Encoding` here.

Fixes TCN-151.
