### PR TITLE
Use registration order to prioritize client Accept-Encoding

### DIFF
--- a/client.go
+++ b/client.go
@@ -46,8 +46,11 @@ func NewClient[Req, Res any](httpClient HTTPClient, url string, options ...Clien
 	client.config = config
 	protocolClient, protocolErr := client.config.Protocol.NewClient(
 		&protocolClientParams{
-			CompressionName:  config.RequestCompressionName,
-			CompressionPools: newReadOnlyCompressionPools(config.CompressionPools),
+			CompressionName: config.RequestCompressionName,
+			CompressionPools: newReadOnlyCompressionPools(
+				config.CompressionPools,
+				config.CompressionNames,
+			),
 			Codec:            config.Codec,
 			Protobuf:         config.protobuf(),
 			CompressMinBytes: config.CompressMinBytes,
@@ -173,6 +176,7 @@ type clientConfig struct {
 	CompressMinBytes       int
 	Interceptor            Interceptor
 	CompressionPools       map[string]*compressionPool
+	CompressionNames       []string
 	Codec                  Codec
 	RequestCompressionName string
 	BufferPool             *bufferPool

--- a/compression.go
+++ b/compression.go
@@ -154,14 +154,19 @@ type readOnlyCompressionPools interface {
 	CommaSeparatedNames() string
 }
 
-func newReadOnlyCompressionPools(nameToPool map[string]*compressionPool) readOnlyCompressionPools {
-	knownNames := make([]string, 0, len(nameToPool))
-	for name := range nameToPool {
-		knownNames = append(knownNames, name)
+func newReadOnlyCompressionPools(
+	nameToPool map[string]*compressionPool,
+	reversedNames []string,
+) readOnlyCompressionPools {
+	// Client and handler configs keep compression names in registration order,
+	// but we want the last registered to be the most preferred.
+	names := make([]string, 0, len(reversedNames))
+	for i := len(reversedNames) - 1; i >= 0; i-- {
+		names = append(names, reversedNames[i])
 	}
 	return &namedCompressionPools{
 		nameToPool:          nameToPool,
-		commaSeparatedNames: strings.Join(knownNames, ","),
+		commaSeparatedNames: strings.Join(names, ","),
 	}
 }
 

--- a/handler.go
+++ b/handler.go
@@ -274,6 +274,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 
 type handlerConfig struct {
 	CompressionPools map[string]*compressionPool
+	CompressionNames []string
 	Codecs           map[string]Codec
 	CompressMinBytes int
 	Interceptor      Interceptor
@@ -319,7 +320,10 @@ func (c *handlerConfig) newProtocolHandlers(streamType StreamType) []protocolHan
 	}
 	handlers := make([]protocolHandler, 0, len(protocols))
 	codecs := newReadOnlyCodecs(c.Codecs)
-	compressors := newReadOnlyCompressionPools(c.CompressionPools)
+	compressors := newReadOnlyCompressionPools(
+		c.CompressionPools,
+		c.CompressionNames,
+	)
 	for _, protocol := range protocols {
 		handlers = append(handlers, protocol.NewHandler(&protocolHandlerParams{
 			Spec:             c.newSpec(streamType),


### PR DESCRIPTION
We're currently randomizing the client's list of accepted encodings when
sending them to the server. This is bad, since the server uses the first
algorithm it recognizes: ideally the client would send them in
preference order.

This PR changes the client to treat the last registered algorithm as the
most preferred. To minimize divergence, we do the same for handlers.

Fixes #259.
