### PR TITLE
improve test coverage in handler

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -135,7 +135,7 @@ func (r *Request[_]) Header() http.Header {
 }
 
 // internalOnly implements AnyRequest.
-func (e *Request[_]) internalOnly() {}
+func (r *Request[_]) internalOnly() {}
 
 // AnyRequest is the common method set of all Requests, regardless of type
 // parameter. It's used in unary interceptors.
@@ -196,7 +196,7 @@ func (r *Response[_]) Trailer() http.Header {
 }
 
 // internalOnly implements AnyResponse.
-func (e *Response[_]) internalOnly() {}
+func (r *Response[_]) internalOnly() {}
 
 // AnyResponse is the common method set of all Responses, regardless of type
 // parameter. It's used in unary interceptors.

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bufbuild/connect-go/internal/assert"
+	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
+)
+
+func TestHandler_ServeHTTP(t *testing.T) {
+	t.Parallel()
+	const procedure = "/connect.ping.v1.PingService/Ping"
+	handler := NewUnaryHandler[pingv1.PingRequest, pingv1.PingResponse](
+		procedure,
+		func(ctx context.Context, req *Request[pingv1.PingRequest]) (*Response[pingv1.PingResponse], error) {
+			return nil, NewError(CodeUnimplemented, nil)
+		})
+	server := httptest.NewServer(handler)
+	client := server.Client()
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	t.Run("method_not_allowed", func(t *testing.T) {
+		t.Parallel()
+		resp, err := client.Get(server.URL + procedure)
+		assert.Nil(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, resp.StatusCode, http.StatusMethodNotAllowed)
+		assert.Equal(t, resp.Header.Get("Allow"), http.MethodPost)
+	})
+
+	t.Run("unsupported_content_type", func(t *testing.T) {
+		t.Parallel()
+		resp, err := client.Post(server.URL+procedure, "application/x-custom-json", strings.NewReader("{}"))
+		assert.Nil(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, resp.StatusCode, http.StatusUnsupportedMediaType)
+		assert.Equal(t, resp.Header.Get("Accept-Post"), handler.acceptPost)
+	})
+}

--- a/protocol.go
+++ b/protocol.go
@@ -74,7 +74,7 @@ type protocolHandler interface {
 	// handle.
 	ContentTypes() map[string]struct{}
 
-	// ParseTimeout runs before NewStream. Implementations may inspect the HTTP
+	// SetTimeout runs before NewStream. Implementations may inspect the HTTP
 	// request, parse any timeout set by the client, and return a modified
 	// context and cancellation function.
 	//


### PR DESCRIPTION
Add some tests to verify the HTTP 405/415 errors. Refactor the code to
simplify readability. Fix a documentation typo and use consistent
receiver names in connect.go.

**Before submitting your PR:** Please read through the contribution guide at https://github.com/bufbuild/connect-go/blob/main/.github/CONTRIBUTING.md
