### PR TITLE
add test for custom handler/client compression

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -547,7 +547,8 @@ func Test_CustomCompression(t *testing.T) {
 	mux := http.NewServeMux()
 	compressionName := "deflate"
 	decompressor := func() connect.Decompressor {
-		return newDeflateReader(http.NoBody)
+		// Need to instantiate with a reader - before decompressing Reset(io.Reader) is called
+		return newDeflateReader(strings.NewReader(""))
 	}
 	compressor := func() connect.Compressor {
 		w, err := flate.NewWriter(&strings.Builder{}, flate.DefaultCompression)

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -140,7 +140,7 @@ func (d *duplexHTTPCall) Trailer() http.Header {
 func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 	// First, we wait until we've gotten the response headers and established the
 	// server-to-client side of the stream.
-	<-d.responseReady
+	d.BlockUntilResponseReady()
 	if err := d.getError(); err != nil {
 		// The stream is already closed or corrupted.
 		return 0, err
@@ -157,7 +157,7 @@ func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 }
 
 func (d *duplexHTTPCall) CloseRead() error {
-	<-d.responseReady
+	d.BlockUntilResponseReady()
 	if d.response == nil {
 		return nil
 	}
@@ -169,7 +169,7 @@ func (d *duplexHTTPCall) CloseRead() error {
 
 // ResponseStatusCode is the response's HTTP status code.
 func (d *duplexHTTPCall) ResponseStatusCode() (int, error) {
-	<-d.responseReady
+	d.BlockUntilResponseReady()
 	if d.response == nil {
 		return 0, fmt.Errorf("nil response from %v", d.request.URL)
 	}

--- a/handler_ext_test.go
+++ b/handler_ext_test.go
@@ -77,6 +77,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		resp, err := client.Do(req)
 		assert.Nil(t, err)
 		defer resp.Body.Close()
+		assert.Equal(t, resp.StatusCode, http.StatusNotFound)
+
 		type errorMessage struct {
 			Code, Message string
 		}
@@ -85,7 +87,6 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, message.Message, `unknown compression "invalid": supported encodings are gzip`)
 		assert.Equal(t, message.Code, connect.CodeUnimplemented.String())
-		assert.Equal(t, resp.StatusCode, http.StatusNotFound)
 	})
 }
 


### PR DESCRIPTION
Create a test which adds support for 'deflate' compression using the
stdlib. Expand test coverage in handler_ext_test to add a test for
unsupported content encoding. Consistently call
`d.BlockUntilResponseReady()` in all places in duplex_http_call.

**Before submitting your PR:** Please read through the contribution guide at https://github.com/bufbuild/connect-go/blob/main/.github/CONTRIBUTING.md
