### PR TITLE
add tests for connect timeout handling

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -542,7 +542,7 @@ func TestCompressMinBytes(t *testing.T) {
 	})
 }
 
-func Test_CustomCompression(t *testing.T) {
+func TestCustomCompression(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
 	compressionName := "deflate"
@@ -575,7 +575,7 @@ func Test_CustomCompression(t *testing.T) {
 	assert.Equal(t, response.Msg, &pingv1.PingResponse{Text: request.Text})
 }
 
-func Test_ConnectTimeout(t *testing.T) {
+func TestConnectTimeout(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
 	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}))

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -575,7 +575,7 @@ func TestCustomCompression(t *testing.T) {
 	assert.Equal(t, response.Msg, &pingv1.PingResponse{Text: request.Text})
 }
 
-func TestConnectTimeout(t *testing.T) {
+func TestInvalidHeaderTimeout(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
 	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}))

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -583,7 +583,6 @@ func TestInvalidHeaderTimeout(t *testing.T) {
 	t.Cleanup(func() {
 		server.Close()
 	})
-
 	getPingResponseWithTimeout := func(t *testing.T, timeout string) *http.Response {
 		t.Helper()
 		request, err := http.NewRequest(http.MethodPost, server.URL+"/"+pingv1connect.PingServiceName+"/Ping", strings.NewReader("{}"))
@@ -597,12 +596,10 @@ func TestInvalidHeaderTimeout(t *testing.T) {
 		})
 		return response
 	}
-
 	t.Run("timeout_non_numeric", func(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, getPingResponseWithTimeout(t, "10s").StatusCode, http.StatusBadRequest)
 	})
-
 	t.Run("timeout_out_of_range", func(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, getPingResponseWithTimeout(t, "12345678901").StatusCode, http.StatusBadRequest)


### PR DESCRIPTION
Update connect_ext_test to add tests to verify error handling with
invalid timeouts.

**Before submitting your PR:** Please read through the contribution guide at https://github.com/bufbuild/connect-go/blob/main/.github/CONTRIBUTING.md
