### PR TITLE
don't set accept-encoding in responses

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -46,6 +46,9 @@ const (
 	clientHeader   = "Connect-Client-Header"
 	handlerHeader  = "Connect-Handler-Header"
 	handlerTrailer = "Connect-Handler-Trailer"
+
+	acceptEncoding     = "Accept-Encoding"
+	grpcAcceptEncoding = "Grpc-Accept-Encoding"
 )
 
 func TestServer(t *testing.T) {
@@ -61,6 +64,10 @@ func TestServer(t *testing.T) {
 			assert.Equal(t, response.Msg, expect)
 			assert.Equal(t, response.Header().Get(handlerHeader), headerValue)
 			assert.Equal(t, response.Trailer().Get(handlerTrailer), trailerValue)
+			for _, invalidResponseHeader := range []string{acceptEncoding, grpcAcceptEncoding} {
+				assert.Equal(t, response.Header().Get(invalidResponseHeader), "")
+				assert.Equal(t, response.Trailer().Get(invalidResponseHeader), "")
+			}
 		})
 		t.Run("zero_ping", func(t *testing.T) {
 			request := connect.NewRequest(&pingv1.PingRequest{})

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -140,7 +140,9 @@ func (h *connectHandler) NewStream(
 			header[connectStreamingHeaderCompression] = []string{responseCompression}
 		}
 	}
-	header[acceptCompressionHeader] = []string{h.CompressionPools.CommaSeparatedNames()}
+	if h.Spec.IsClient {
+		header[acceptCompressionHeader] = []string{h.CompressionPools.CommaSeparatedNames()}
+	}
 
 	codecName := connectCodecFromContentType(
 		h.Spec.StreamType,

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -152,7 +152,9 @@ func (g *grpcHandler) NewStream(
 	// skip the normalization in Header.Set.
 	header := responseWriter.Header()
 	header[headerContentType] = []string{request.Header.Get(headerContentType)}
-	header[grpcHeaderAcceptCompression] = []string{g.CompressionPools.CommaSeparatedNames()}
+	if g.Spec.IsClient {
+		header[grpcHeaderAcceptCompression] = []string{g.CompressionPools.CommaSeparatedNames()}
+	}
 	if responseCompression != compressionIdentity {
 		header[grpcHeaderCompression] = []string{responseCompression}
 	}


### PR DESCRIPTION
For both the Connect and gRPC protocols, we're setting 'accept-encoding'
or 'grpc-accept-encoding' in the responses (this should only be sent in
requests).