### PR TITLE
add timeout test to streaming client call

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -171,6 +171,13 @@ func TestServer(t *testing.T) {
 				connect.CodeInvalidArgument,
 			)
 		})
+		t.Run("count_up_timeout", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+			defer cancel()
+			_, err := client.CountUp(ctx, connect.NewRequest(&pingv1.CountUpRequest{Number: 1}))
+			assert.NotNil(t, err)
+			assert.Equal(t, connect.CodeOf(err), connect.CodeDeadlineExceeded)
+		})
 	}
 	testCumSum := func(t *testing.T, client pingv1connect.PingServiceClient, expectSuccess bool) { // nolint:thelper
 		t.Run("cumsum", func(t *testing.T) {


### PR DESCRIPTION
There is an existing test for unary calls - add a similar test to verify
streaming calls.
