### PR TITLE
Always use unix-style paths for CodeGeneratorResponses

### DIFF
--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -100,12 +100,11 @@ func generate(plugin *protogen.Plugin, file *protogen.File) {
 	}
 	file.GoPackageName += generatedPackageSuffix
 
-	dir := filepath.Dir(file.GeneratedFilenamePrefix)
-	base := filepath.Base(file.GeneratedFilenamePrefix)
-	file.GeneratedFilenamePrefix = filepath.Join(
-		dir,
+	generatedFilenamePrefixToSlash := filepath.ToSlash(file.GeneratedFilenamePrefix)
+	file.GeneratedFilenamePrefix = path.Join(
+		path.Dir(generatedFilenamePrefixToSlash),
 		string(file.GoPackageName),
-		base,
+		path.Base(generatedFilenamePrefixToSlash),
 	)
 	generatedFile := plugin.NewGeneratedFile(
 		file.GeneratedFilenamePrefix+generatedFilenameExtension,


### PR DESCRIPTION
Fixes https://github.com/bufbuild/connect-go/issues/297.

`protoc` and `buf` both expect `CodeGeneratorResponses` to have unix-style paths https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/compiler/plugin.proto#L124=