### PR TITLE
feat: Add NewHTTPClient

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -218,6 +218,18 @@ type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
+type httpClient struct{ http.RoundTripper }
+
+func (c httpClient) Do(req *http.Request) (*http.Response, error) {
+	return c.RoundTrip(req)
+}
+
+// NewHTTPClient wraps an http.RoundTripper to make it satisfy the HTTPClient
+// interface.
+func NewHTTPClient(rt http.RoundTripper) HTTPClient {
+	return httpClient{rt}
+}
+
 // Spec is a description of a client call or a handler invocation.
 type Spec struct {
 	StreamType StreamType


### PR DESCRIPTION
The HTTPClient interface is effectively the same thing as an
http.RoundTripper, but instead, I understand the desire for HTTPClient's
interface to work with a *http.Client.

It's also rather intuitive to directly use an http.RoundTripper which is
just the inner implementation of an *http.Client.

This makes it slightly easier to use different transports or different
implementations by just swapping out a RoundTripper without needing to
wrap in an *http.Client yourself.

The stdlib *http.Client comes with extra baggage that might not be
desirable for use within RPC, such as following redirects and management
for cookies.

**Before submitting your PR:** Please read through the contribution guide at https://github.com/bufbuild/connect-go/blob/main/.github/CONTRIBUTING.md
