### PR TITLE
attempt to fix flaky timeout tests

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -93,9 +93,8 @@ func TestServer(t *testing.T) {
 			assert.Equal(t, connect.CodeOf(err), connect.CodeInvalidArgument)
 		})
 		t.Run("ping_timout", func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 			defer cancel()
-			time.Sleep(2 * time.Millisecond)
 			request := connect.NewRequest(&pingv1.PingRequest{})
 			request.Header().Set(clientHeader, headerValue)
 			_, err := client.Ping(ctx, request)
@@ -173,9 +172,8 @@ func TestServer(t *testing.T) {
 			)
 		})
 		t.Run("count_up_timeout", func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 			defer cancel()
-			time.Sleep(2 * time.Millisecond)
 			_, err := client.CountUp(ctx, connect.NewRequest(&pingv1.CountUpRequest{Number: 1}))
 			assert.NotNil(t, err)
 			assert.Equal(t, connect.CodeOf(err), connect.CodeDeadlineExceeded)


### PR DESCRIPTION
Instead of using time.Sleep with small increments, instead create a
context using `WithDeadline(...)` with an expired time.
