### PR TITLE
Rework streaming interceptors

### DIFF
--- a/client_stream_test.go
+++ b/client_stream_test.go
@@ -57,8 +57,8 @@ func TestBidiStreamForClient_NoPanics(t *testing.T) {
 	verifyHeaders(t, bidiStream.ResponseHeader())
 	verifyHeaders(t, bidiStream.ResponseTrailer())
 	assert.ErrorIs(t, bidiStream.Send(&pingv1.CumSumRequest{}), initErr)
-	assert.ErrorIs(t, bidiStream.CloseReceive(), initErr)
-	assert.ErrorIs(t, bidiStream.CloseSend(), initErr)
+	assert.ErrorIs(t, bidiStream.CloseRequest(), initErr)
+	assert.ErrorIs(t, bidiStream.CloseResponse(), initErr)
 }
 
 func verifyHeaders(t *testing.T, headers http.Header) {

--- a/code.go
+++ b/code.go
@@ -142,10 +142,12 @@ func (c Code) String() string {
 	return fmt.Sprintf("code_%d", c)
 }
 
+// MarshalText implements encoding.TextMarshaler.
 func (c Code) MarshalText() ([]byte, error) {
 	return []byte(c.String()), nil
 }
 
+// UnmarshalText implements encoding.TextUnmarshaler.
 func (c *Code) UnmarshalText(data []byte) error {
 	dataStr := string(data)
 	switch dataStr {

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/bufbuild/connect-go"
@@ -26,68 +25,6 @@ import (
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
 )
-
-func TestClientStreamErrors(t *testing.T) {
-	t.Parallel()
-	_, err := pingv1connect.
-		NewPingServiceClient(http.DefaultClient, "INVALID_URL").
-		Ping(context.Background(), nil)
-	assert.NotNil(t, err)
-	assert.Match(t, err.Error(), "missing scheme")
-	// We don't even get to calling methods on the client, so there's no question
-	// of interceptors running. Once we're calling methods on the client, all
-	// errors are visible to interceptors.
-}
-
-func TestHandlerStreamErrors(t *testing.T) {
-	t.Parallel()
-	// If we receive an HTTP request and send a response, interceptors should
-	// fire - even if we can't successfully set up a stream. (This is different
-	// from clients, where stream creation fails before any HTTP request is
-	// issued.)
-	var called bool
-	reset := func() {
-		called = false
-	}
-	mux := http.NewServeMux()
-	mux.Handle(pingv1connect.NewPingServiceHandler(
-		pingServer{},
-		connect.WithInterceptors(&assertCalledInterceptor{&called}),
-	))
-	server := httptest.NewServer(mux)
-	defer server.Close()
-
-	t.Run("unary", func(t *testing.T) { // nolint:paralleltest
-		defer reset()
-		request, err := http.NewRequest(
-			http.MethodPost,
-			server.URL+"/connect.ping.v1.PingService/Ping",
-			strings.NewReader(""),
-		)
-		assert.Nil(t, err)
-		request.Header.Set("Content-Type", "application/grpc+proto")
-		request.Header.Set("Grpc-Timeout", "INVALID")
-		res, err := server.Client().Do(request)
-		assert.Nil(t, err)
-		assert.Equal(t, res.StatusCode, http.StatusOK)
-		assert.True(t, called)
-	})
-	t.Run("stream", func(t *testing.T) { // nolint:paralleltest
-		defer reset()
-		request, err := http.NewRequest(
-			http.MethodPost,
-			server.URL+"/connect.ping.v1.PingService/CountUp",
-			strings.NewReader(""),
-		)
-		assert.Nil(t, err)
-		request.Header.Set("Content-Type", "application/grpc+proto")
-		request.Header.Set("Grpc-Timeout", "INVALID")
-		res, err := server.Client().Do(request)
-		assert.Nil(t, err)
-		assert.Equal(t, res.StatusCode, http.StatusOK)
-		assert.True(t, called)
-	})
-}
 
 func TestOnionOrderingEndToEnd(t *testing.T) {
 	t.Parallel()
@@ -188,10 +125,18 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 		server.URL,
 		clientOnion,
 	)
+
 	_, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{Number: 10}))
 	assert.Nil(t, err)
-	_, err = client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
+
+	responses, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
 	assert.Nil(t, err)
+	var sum int64
+	for responses.Receive() {
+		sum += responses.Msg().Number
+	}
+	assert.Equal(t, sum, 55)
+	assert.Nil(t, responses.Close())
 }
 
 // headerInterceptor makes it easier to write interceptors that inspect or
@@ -236,84 +181,63 @@ func (h *headerInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc 
 	}
 }
 
-func (h *headerInterceptor) WrapStreamContext(ctx context.Context) context.Context {
-	return ctx
+func (h *headerInterceptor) WrapStreamingClient(next connect.ClientConnFunc) connect.ClientConnFunc {
+	return connect.ClientConnFunc(func(ctx context.Context, spec connect.Spec) connect.ClientConn {
+		return &headerInspectingClientConn{
+			ClientConn:            next(ctx, spec),
+			inspectRequestHeader:  h.inspectRequestHeader,
+			inspectResponseHeader: h.inspectResponseHeader,
+		}
+	})
 }
 
-// WrapStreamSender implements Interceptor. Depending on whether it's operating
-// on a client or handler, it wraps the sender with the request- or
-// response-inspecting function.
-func (h *headerInterceptor) WrapStreamSender(ctx context.Context, sender connect.Sender) connect.Sender {
-	if sender.Spec().IsClient {
-		return &headerInspectingSender{Sender: sender, inspect: h.inspectRequestHeader}
+func (h *headerInterceptor) WrapStreamingHandler(next connect.HandlerConnFunc) connect.HandlerConnFunc {
+	return connect.HandlerConnFunc(func(ctx context.Context, conn connect.HandlerConn) error {
+		h.inspectRequestHeader(conn.Spec(), conn.RequestHeader())
+		return next(ctx, &headerInspectingHandlerConn{
+			HandlerConn:           conn,
+			inspectResponseHeader: h.inspectResponseHeader,
+		})
+	})
+}
+
+type headerInspectingHandlerConn struct {
+	connect.HandlerConn
+
+	inspectedResponse     bool
+	inspectResponseHeader func(connect.Spec, http.Header)
+}
+
+func (hc *headerInspectingHandlerConn) Send(msg any) error {
+	if !hc.inspectedResponse {
+		hc.inspectResponseHeader(hc.Spec(), hc.ResponseHeader())
+		hc.inspectedResponse = true
 	}
-	return &headerInspectingSender{Sender: sender, inspect: h.inspectResponseHeader}
+	return hc.HandlerConn.Send(msg)
 }
 
-// WrapStreamReceiver implements Interceptor. Depending on whether it's
-// operating on a client or handler, it wraps the sender with the response- or
-// request-inspecting function.
-func (h *headerInterceptor) WrapStreamReceiver(ctx context.Context, receiver connect.Receiver) connect.Receiver {
-	if receiver.Spec().IsClient {
-		return &headerInspectingReceiver{Receiver: receiver, inspect: h.inspectResponseHeader}
+type headerInspectingClientConn struct {
+	connect.ClientConn
+
+	inspectedRequest      bool
+	inspectRequestHeader  func(connect.Spec, http.Header)
+	inspectedResponse     bool
+	inspectResponseHeader func(connect.Spec, http.Header)
+}
+
+func (cc *headerInspectingClientConn) Send(msg any) error {
+	if !cc.inspectedRequest {
+		cc.inspectRequestHeader(cc.Spec(), cc.RequestHeader())
+		cc.inspectedRequest = true
 	}
-	return &headerInspectingReceiver{Receiver: receiver, inspect: h.inspectRequestHeader}
+	return cc.ClientConn.Send(msg)
 }
 
-type headerInspectingSender struct {
-	connect.Sender
-
-	called  bool // senders don't need to be thread-safe
-	inspect func(connect.Spec, http.Header)
-}
-
-func (s *headerInspectingSender) Send(m any) error {
-	if !s.called {
-		s.inspect(s.Spec(), s.Header())
-		s.called = true
+func (cc *headerInspectingClientConn) Receive(msg any) error {
+	err := cc.ClientConn.Receive(msg)
+	if !cc.inspectedResponse {
+		cc.inspectResponseHeader(cc.Spec(), cc.ResponseHeader())
+		cc.inspectedResponse = true
 	}
-	return s.Sender.Send(m)
-}
-
-type headerInspectingReceiver struct {
-	connect.Receiver
-
-	called  bool // receivers don't need to be thread-safe
-	inspect func(connect.Spec, http.Header)
-}
-
-func (r *headerInspectingReceiver) Receive(m any) error {
-	if !r.called {
-		r.inspect(r.Spec(), r.Header())
-		r.called = true
-	}
-	if err := r.Receiver.Receive(m); err != nil {
-		return err
-	}
-	return nil
-}
-
-type assertCalledInterceptor struct {
-	called *bool
-}
-
-func (i *assertCalledInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
-	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-		*i.called = true
-		return next(ctx, req)
-	}
-}
-
-func (i *assertCalledInterceptor) WrapStreamContext(ctx context.Context) context.Context {
-	return ctx
-}
-
-func (i *assertCalledInterceptor) WrapStreamSender(_ context.Context, sender connect.Sender) connect.Sender {
-	*i.called = true
-	return sender
-}
-
-func (i *assertCalledInterceptor) WrapStreamReceiver(_ context.Context, receiver connect.Receiver) connect.Receiver {
-	*i.called = true
-	return receiver
+	return err
 }


### PR DESCRIPTION
Streaming interceptors aren't very useful in their current state. Rather
than wrapping user code, they wrap the the networking primitives used by
the user's code. This is a subtle distinction, but it makes it
impossible to write a panic-recovering interceptor. It also makes common
server-side interceptors (e.g., authentication) needlessly difficult to
write.

This commit reworks the Sender and Receiver interfaces into a ClientConn
and HandlerConn. Just as unary interceptors wrap a UnaryFunc, streaming
interceptors now wrap ClientConnFuncs and HandlerConnFuncs. This ends up
being quite a bit easier to understand.

Connect's internals change a lot, but the user-visible changes are
modest. Today, we have:

```go
type Sender interface {
  Spec() Spec
  Send(any) error
  Header() http.Header
  Trailer() (http.Header, bool)
  Close(error) error
}

type Receiver interface {
  Spec() Spec
  Receive(any) error
  Header() http.Header
  Trailer() (http.Header, bool)
  Close() error
}

type Interceptor interface {
  WrapUnary(UnaryFunc) UnaryFunc
  WrapStreamContext(context.Context) context.Context
  WrapStreamSender(context.Context, Sender) Sender
  WrapStreamReceiver(context.Context, Receiver) Receiver
}
```

With this commit, we change to:

```go
type ClientConn interface {
  Spec() Spec

  Send(any) error
  RequestHeader() http.Header
  CloseRequest() error

  Receive(any) error
  ResponseHeader() http.Header
  ResponseTrailer() http.Header
  CloseResponse() error
}

type HandlerConn interface {
  Spec() Spec

  Receive(any) error
  RequestHeader() http.Header

  Send(any) error
  ResponseHeader() http.Header
  ResponseTrailer() http.Header
  Close(error) error
}

type ClientConnFunc func(Spec, http.Header) ClientConn

type HandlerConnFunc func(context.Context, HandlerConn) error

type Interceptor interface {
  WrapUnary(UnaryFunc) UnaryFunc
  WrapStreamingClient(ClientConnFunc) ClientConnFunc
  WrapStreamingHandler(HandlerConnFunc) HandlerConnFunc
}
```

Fixes #296.