### PR TITLE
improve decompress signature

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -144,7 +144,7 @@ func (r *envelopeReader) Unmarshal(message any) *Error {
 		}
 		decompressed := r.bufferPool.Get()
 		defer r.bufferPool.Put(decompressed)
-		if err := r.compressionPool.Decompress(decompressed, data, r.readMaxBytes); err != nil {
+		if err := r.compressionPool.Decompress(decompressed, data, int64(r.readMaxBytes)); err != nil {
 			return err
 		}
 		data = decompressed

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -792,7 +792,7 @@ func (u *connectUnaryUnmarshaler) UnmarshalFunc(message any, unmarshal func([]by
 	if data.Len() > 0 && u.compressionPool != nil {
 		decompressed := u.bufferPool.Get()
 		defer u.bufferPool.Put(decompressed)
-		if err := u.compressionPool.Decompress(decompressed, data, u.readMaxBytes); err != nil {
+		if err := u.compressionPool.Decompress(decompressed, data, int64(u.readMaxBytes)); err != nil {
 			return err
 		}
 		data = decompressed


### PR DESCRIPTION
Remove duplicate casts in compression pool's Decompress function by
ensuring the maxReadBytes parameter is an int64. This requires fewer
casts in the implementation to avoid potential issues.
