### PR TITLE
Add an option for panic-recovering interceptor

### DIFF
--- a/option.go
+++ b/option.go
@@ -132,9 +132,9 @@ func WithHandlerOptions(options ...HandlerOption) HandlerOption {
 
 // WithRecover adds an interceptor that recovers from panics. The supplied
 // function receives the context, Spec, request headers, and the recovered
-// value. It must return an error to send back to the client. It may also log
-// the panic, emit metrics, or execute other error-handling logic. Handler
-// functions must be safe to call concurrently.
+// value. It must return an error to send back to the client and be safe to
+// call concurrently. The function may also log the panic, emit metrics, or
+// execute other error-handling logic.
 //
 // To preserve compatibility with net/http's semantics, this interceptor
 // doesn't handle panics with http.ErrAbortHandler.

--- a/option.go
+++ b/option.go
@@ -132,9 +132,9 @@ func WithHandlerOptions(options ...HandlerOption) HandlerOption {
 
 // WithRecover adds an interceptor that recovers from panics. The supplied
 // function receives the context, Spec, request headers, and the recovered
-// value. It must return an error to send back to the client and be safe to
-// call concurrently. The function may also log the panic, emit metrics, or
-// execute other error-handling logic.
+// value (which may be nil). It must return an error to send back to the
+// client. It may also log the panic, emit metrics, or execute other
+// error-handling logic. Handler functions must be safe to call concurrently.
 //
 // To preserve compatibility with net/http's semantics, this interceptor
 // doesn't handle panics with http.ErrAbortHandler.

--- a/option.go
+++ b/option.go
@@ -16,7 +16,9 @@ package connect
 
 import (
 	"compress/gzip"
+	"context"
 	"io"
+	"net/http"
 )
 
 // A ClientOption configures a connect client.
@@ -126,6 +128,24 @@ func WithCompression(
 // WithHandlerOptions composes multiple HandlerOptions into one.
 func WithHandlerOptions(options ...HandlerOption) HandlerOption {
 	return &handlerOptionsOption{options}
+}
+
+// WithRecover adds an interceptor that recovers from panics. The supplied
+// function receives the context, Spec, request headers, and the recovered
+// value. It must return an error to send back to the client. It may also log
+// the panic, emit metrics, or execute other error-handling logic. Handler
+// functions must be safe to call concurrently.
+//
+// To preserve compatibility with net/http's semantics, this interceptor
+// doesn't handle panics with http.ErrAbortHandler.
+//
+// By default, handlers don't recover from panics. Because the standard
+// library's http.Server recovers from panics by default, this option isn't
+// usually necessary to prevent crashes. Instead, it helps servers collect
+// RPC-specific data during panics and send a more detailed error to
+// clients.
+func WithRecover(handle func(context.Context, Spec, http.Header, any) error) HandlerOption {
+	return WithInterceptors(&recoverHandlerInterceptor{handle: handle})
 }
 
 // Option implements both ClientOption and HandlerOption, so it can be applied

--- a/recover.go
+++ b/recover.go
@@ -1,0 +1,80 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect
+
+import (
+	"context"
+	"net/http"
+)
+
+// recoverHandlerInterceptor lets handlers trap panics, perform side effects
+// (like emitting logs or metrics), and present a friendlier error message to
+// clients.
+//
+// This interceptor uses a somewhat unusual strategy to recover from panics.
+// The standard recovery idiom:
+//
+//   if r := recover(); r != nil { ... }
+//
+// isn't robust in the face of user error, because it doesn't handle
+// panic(nil). This occasionally happens by mistake, and it's a beast to debug
+// without a more robust idiom. See https://github.com/golang/go/issues/25448
+// for details.
+type recoverHandlerInterceptor struct {
+	Interceptor
+
+	handle func(context.Context, Spec, http.Header, any) error
+}
+
+func (i *recoverHandlerInterceptor) WrapUnary(next UnaryFunc) UnaryFunc {
+	return func(ctx context.Context, req AnyRequest) (_ AnyResponse, retErr error) { // nolint:nonamedreturns
+		if req.Spec().IsClient {
+			return next(ctx, req)
+		}
+		panicked := true
+		defer func() {
+			if panicked {
+				r := recover()
+				// net/http checks for ErrAbortHandler with ==, so we should too.
+				if r == http.ErrAbortHandler { // nolint:errorlint,goerr113
+					panic(r) // nolint:forbidigo
+				}
+				retErr = i.handle(ctx, req.Spec(), req.Header(), r)
+			}
+		}()
+		res, err := next(ctx, req)
+		panicked = false
+		return res, err
+	}
+}
+
+func (i *recoverHandlerInterceptor) WrapStreamingHandler(next StreamingHandlerFunc) StreamingHandlerFunc {
+	return func(ctx context.Context, conn StreamingHandlerConn) (retErr error) { // nolint:nonamedreturns
+		panicked := true
+		defer func() {
+			if panicked {
+				r := recover()
+				// net/http checks for ErrAbortHandler with ==, so we should too.
+				if r == http.ErrAbortHandler { // nolint:errorlint,goerr113
+					panic(r) // nolint:forbidigo
+				}
+				retErr = i.handle(ctx, Spec{}, nil, r)
+			}
+		}()
+		err := next(ctx, conn)
+		panicked = false
+		return err
+	}
+}

--- a/recover_ext_test.go
+++ b/recover_ext_test.go
@@ -1,0 +1,104 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bufbuild/connect-go"
+	"github.com/bufbuild/connect-go/internal/assert"
+	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
+	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
+)
+
+type panicPingServer struct {
+	pingv1connect.UnimplementedPingServiceHandler
+
+	panicWith any
+}
+
+func (s *panicPingServer) Ping(
+	context.Context,
+	*connect.Request[pingv1.PingRequest],
+) (*connect.Response[pingv1.PingResponse], error) {
+	panic(s.panicWith) // nolint:forbidigo
+}
+
+func (s *panicPingServer) CountUp(
+	context.Context,
+	*connect.Request[pingv1.CountUpRequest],
+	*connect.ServerStream[pingv1.CountUpResponse],
+) error {
+	panic(s.panicWith) // nolint:forbidigo
+}
+
+func TestWithRecover(t *testing.T) {
+	t.Parallel()
+	handle := func(_ context.Context, _ connect.Spec, _ http.Header, r any) error {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("panic: %v", r))
+	}
+	assertHandled := func(err error) {
+		t.Helper()
+		assert.NotNil(t, err)
+		assert.Equal(t, connect.CodeOf(err), connect.CodeFailedPrecondition)
+	}
+	assertNotHandled := func(err error) {
+		t.Helper()
+		if err != nil {
+			assert.NotEqual(t, connect.CodeOf(err), connect.CodeFailedPrecondition)
+		}
+	}
+	drainStream := func(stream *connect.ServerStreamForClient[pingv1.CountUpResponse]) error {
+		t.Helper()
+		defer stream.Close()
+		assert.False(t, stream.Receive())
+		return stream.Err()
+	}
+	pinger := &panicPingServer{}
+	mux := http.NewServeMux()
+	mux.Handle(pingv1connect.NewPingServiceHandler(pinger, connect.WithRecover(handle)))
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+	client := pingv1connect.NewPingServiceClient(
+		server.Client(),
+		server.URL,
+	)
+
+	for _, panicWith := range []any{42, nil} {
+		pinger.panicWith = panicWith
+
+		_, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{}))
+		assertHandled(err)
+
+		stream, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{}))
+		assert.Nil(t, err)
+		assertHandled(drainStream(stream))
+	}
+
+	pinger.panicWith = http.ErrAbortHandler
+
+	_, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{}))
+	assertNotHandled(err)
+
+	stream, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{}))
+	assert.Nil(t, err)
+	assertNotHandled(drainStream(stream))
+}


### PR DESCRIPTION
It's super-common for servers to want to recover from panics and control
the error message that clients see. This PR adds a HandlerOption to
recover from panics.

This is nice to have in connect proper for two reasons:

* Recovering properly is more nuanced than the usual
  `if r := recover(); r != nil`.
* It's a good way to exercise the interceptor API.

FYI @kohenkatz
