### PR TITLE
Map HTTP/2 RST_STREAM codes back to RPC codes

### DIFF
--- a/error.go
+++ b/error.go
@@ -283,7 +283,7 @@ func wrapIfRSTError(err error) error {
 	}
 	msg = strings.TrimSuffix(msg, fromPeerSuffix)
 	i := strings.LastIndex(msg, ";")
-	if i < 0 || i == len(msg) {
+	if i < 0 || i >= len(msg)-1 {
 		return err
 	}
 	msg = msg[i+1:]

--- a/error.go
+++ b/error.go
@@ -270,8 +270,8 @@ func wrapIfRSTError(err error) error {
 		return err
 	}
 	if urlErr := new(url.Error); errors.As(err, &urlErr) {
-		// The *url.Error is wrapping a *http.http2StreamError, which is the
-		// vendored x/net/http2.StreamError.
+		// If we get an RST_STREAM error from http.Client.Do, it's wrapped in a
+		// *url.Error.
 		err = urlErr.Unwrap()
 	}
 	msg := err.Error()


### PR DESCRIPTION
HTTP/2 includes its own set of error codes, which are sent in RST_STREAM
frames. When servers send one of these codes to clients, we should map
the HTTP/2 code back to one of our status codes.
