### PR TITLE
Shorten stability section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,7 @@ stable v1 in October, soon after the Go 1.19 release.
 
 `connect-go` supports:
 
-* The [two most recent major releases][go-support-policy] of Go, with a minimum
-  of Go 1.18.
+* The [two most recent major releases][go-support-policy] of Go.
 * [APIv2] of Protocol Buffers in Go (`google.golang.org/protobuf`).
 
 Within those parameters, Connect follows semantic versioning.


### PR DESCRIPTION
We don't need to special-case Go 1.18 support, since all of the Go
team's supported versions now include generics.

**Before submitting your PR:** Please read through the contribution guide at https://github.com/bufbuild/connect-go/blob/main/.github/CONTRIBUTING.md
