### PR TITLE
Add support for http.MaxBytesHandler

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 )
 
@@ -202,7 +201,7 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 		if connectErr, ok := asError(err); ok {
 			return connectErr
 		}
-		if maxBytesErr := asMaxBytesError("read 5 byte message prefix", err); maxBytesErr != nil {
+		if maxBytesErr := asMaxBytesError(err, "read 5 byte message prefix"); maxBytesErr != nil {
 			// We're reading from an http.MaxBytesHandler, and we've exceeded the read limit.
 			return maxBytesErr
 		}
@@ -232,8 +231,7 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 		for remaining > 0 {
 			bytesRead, err := io.CopyN(env.Data, r.reader, remaining)
 			if err != nil && !errors.Is(err, io.EOF) {
-				situation := fmt.Sprintf("read %d byte message", size)
-				if maxBytesErr := asMaxBytesError(situation, err); maxBytesErr != nil {
+				if maxBytesErr := asMaxBytesError(err, "read %d byte message", size); maxBytesErr != nil {
 					// We're reading from an http.MaxBytesHandler, and we've exceeded the read limit.
 					return maxBytesErr
 				}

--- a/maxbytes.go
+++ b/maxbytes.go
@@ -18,13 +18,15 @@ package connect
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 )
 
-func asMaxBytesError(situation string, err error) *Error {
+func asMaxBytesError(err error, tmpl string, args ...any) *Error {
 	var maxBytesErr *http.MaxBytesError
 	if ok := errors.As(err, &maxBytesErr); !ok {
 		return nil
 	}
-	return errorf(CodeResourceExhausted, "%s: exceeded %d byte http.MaxBytesReader limit", situation, maxBytesErr.Limit)
+	prefix := fmt.Sprintf(tmpl, args...)
+	return errorf(CodeResourceExhausted, "%s: exceeded %d byte http.MaxBytesReader limit", prefix, maxBytesErr.Limit)
 }

--- a/maxbytes.go
+++ b/maxbytes.go
@@ -1,0 +1,30 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.19
+
+package connect
+
+import (
+	"errors"
+	"net/http"
+)
+
+func asMaxBytesError(situation string, err error) *Error {
+	var maxBytesErr *http.MaxBytesError
+	if ok := errors.As(err, &maxBytesErr); !ok {
+		return nil
+	}
+	return errorf(CodeResourceExhausted, "%s: exceeded %d byte http.MaxBytesReader limit", situation, maxBytesErr.Limit)
+}

--- a/maxbytes_go118.go
+++ b/maxbytes_go118.go
@@ -16,13 +16,17 @@
 
 package connect
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
-func asMaxBytesError(situation string, err error) *Error {
+func asMaxBytesError(err error, tmpl string, args ...any) *Error {
 	const expect = "http: request body too large"
 	text := err.Error()
 	if !(text == expect) && !strings.HasSuffix(text, ": "+expect) {
 		return nil
 	}
-	return errorf(CodeResourceExhausted, "%s: exceeded http.MaxBytesReader limit", situation)
+	prefix := fmt.Sprintf(tmpl, args...)
+	return errorf(CodeResourceExhausted, "%s: exceeded http.MaxBytesReader limit", prefix)
 }

--- a/maxbytes_go118.go
+++ b/maxbytes_go118.go
@@ -1,0 +1,28 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.19
+
+package connect
+
+import "strings"
+
+func asMaxBytesError(situation string, err error) *Error {
+	const expect = "http: request body too large"
+	text := err.Error()
+	if !(text == expect) && !strings.HasSuffix(text, ": "+expect) {
+		return nil
+	}
+	return errorf(CodeResourceExhausted, "%s: exceeded http.MaxBytesReader limit", situation)
+}

--- a/maxbytes_go118.go
+++ b/maxbytes_go118.go
@@ -24,7 +24,7 @@ import (
 func asMaxBytesError(err error, tmpl string, args ...any) *Error {
 	const expect = "http: request body too large"
 	text := err.Error()
-	if !(text == expect) && !strings.HasSuffix(text, ": "+expect) {
+	if text != expect && !strings.HasSuffix(text, ": "+expect) {
 		return nil
 	}
 	prefix := fmt.Sprintf(tmpl, args...)

--- a/option.go
+++ b/option.go
@@ -197,6 +197,11 @@ func WithCompressMinBytes(min int) Option {
 //
 // Setting WithReadMaxBytes to zero allows any message size. Both clients and
 // handlers default to allowing any request size.
+//
+// Handlers may also use [http.MaxBytesHandler] to limit the total size of the
+// HTTP request stream (rather than the per-message size). Connect handles
+// [http.MaxBytesError] specially, so clients still receive errors with the
+// appropriate error code and informative messages.
 func WithReadMaxBytes(max int) Option {
 	return &readMaxBytesOption{Max: max}
 }

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -781,6 +781,10 @@ func (u *connectUnaryUnmarshaler) UnmarshalFunc(message any, unmarshal func([]by
 		if connectErr, ok := asError(err); ok {
 			return connectErr
 		}
+		situation := fmt.Sprintf("read first %d bytes of message", bytesRead)
+		if readMaxBytesErr := asMaxBytesError(situation, err); readMaxBytesErr != nil {
+			return readMaxBytesErr
+		}
 		return errorf(CodeUnknown, "read message: %w", err)
 	}
 	if u.readMaxBytes > 0 && bytesRead > int64(u.readMaxBytes) {

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -781,8 +781,7 @@ func (u *connectUnaryUnmarshaler) UnmarshalFunc(message any, unmarshal func([]by
 		if connectErr, ok := asError(err); ok {
 			return connectErr
 		}
-		situation := fmt.Sprintf("read first %d bytes of message", bytesRead)
-		if readMaxBytesErr := asMaxBytesError(situation, err); readMaxBytesErr != nil {
+		if readMaxBytesErr := asMaxBytesError(err, "read first %d bytes of message", bytesRead); readMaxBytesErr != nil {
 			return readMaxBytesErr
 		}
 		return errorf(CodeUnknown, "read message: %w", err)


### PR DESCRIPTION
The `ReadMaxBytes` option is nice, but we should also return
properly-coded errors when `net/http.MaxBytesHandler` middleware is in
play. This has no API surface area, but it's a nice improvement.
