### PR TITLE
Expose peer information to handlers and clients

### DIFF
--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/bufbuild/connect-go"
@@ -67,4 +68,91 @@ func TestNewClient_InitFailure(t *testing.T) {
 		_, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{Number: 3}))
 		validateExpectedError(t, err)
 	})
+}
+
+func TestClientPeer(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}))
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	run := func(t *testing.T, opts ...connect.ClientOption) {
+		t.Helper()
+		client := pingv1connect.NewPingServiceClient(
+			server.Client(),
+			server.URL,
+			connect.WithClientOptions(opts...),
+			connect.WithInterceptors(&assertPeerInterceptor{t}),
+		)
+		ctx := context.Background()
+		// unary
+		_, err := client.Ping(ctx, connect.NewRequest(&pingv1.PingRequest{}))
+		assert.Nil(t, err)
+		// client streaming
+		clientStream := client.Sum(ctx)
+		t.Cleanup(func() {
+			_, closeErr := clientStream.CloseAndReceive()
+			assert.Nil(t, closeErr)
+		})
+		assert.NotNil(t, clientStream.Peer().Addr)
+		err = clientStream.Send(&pingv1.SumRequest{})
+		assert.Nil(t, err)
+		// server streaming
+		serverStream, err := client.CountUp(ctx, connect.NewRequest(&pingv1.CountUpRequest{}))
+		t.Cleanup(func() {
+			assert.Nil(t, serverStream.Close())
+		})
+		assert.Nil(t, err)
+		// bidi streaming
+		bidiStream := client.CumSum(ctx)
+		t.Cleanup(func() {
+			assert.Nil(t, bidiStream.CloseRequest())
+			assert.Nil(t, bidiStream.CloseResponse())
+		})
+		assert.NotNil(t, bidiStream.Peer().Addr)
+		err = bidiStream.Send(&pingv1.CumSumRequest{})
+		assert.Nil(t, err)
+	}
+
+	t.Run("connect", func(t *testing.T) {
+		t.Parallel()
+		run(t)
+	})
+	t.Run("grpc", func(t *testing.T) {
+		t.Parallel()
+		run(t, connect.WithGRPC())
+	})
+	t.Run("grpcweb", func(t *testing.T) {
+		t.Parallel()
+		run(t, connect.WithGRPCWeb())
+	})
+}
+
+type assertPeerInterceptor struct {
+	tb testing.TB
+}
+
+func (a *assertPeerInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		assert.NotZero(a.tb, req.Peer().Addr)
+		return next(ctx, req)
+	}
+}
+
+func (a *assertPeerInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		conn := next(ctx, spec)
+		assert.NotZero(a.tb, conn.Peer().Addr)
+		return conn
+	}
+}
+
+func (a *assertPeerInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		assert.NotZero(a.tb, conn.Peer().Addr)
+		return next(ctx, conn)
+	}
 }

--- a/client_stream.go
+++ b/client_stream.go
@@ -35,6 +35,11 @@ func (c *ClientStreamForClient[_, _]) Spec() Spec {
 	return c.conn.Spec()
 }
 
+// Peer describes the server for the RPC.
+func (c *ClientStreamForClient[_, _]) Peer() Peer {
+	return c.conn.Peer()
+}
+
 // RequestHeader returns the request headers. Headers are sent to the server with the
 // first call to Send.
 func (c *ClientStreamForClient[Req, Res]) RequestHeader() http.Header {
@@ -172,6 +177,11 @@ type BidiStreamForClient[Req, Res any] struct {
 // Spec returns the specification for the RPC.
 func (b *BidiStreamForClient[_, _]) Spec() Spec {
 	return b.conn.Spec()
+}
+
+// Peer describes the server for the RPC.
+func (b *BidiStreamForClient[_, _]) Peer() Peer {
+	return b.conn.Peer()
 }
 
 // RequestHeader returns the request headers. Headers are sent with the first

--- a/client_stream.go
+++ b/client_stream.go
@@ -30,6 +30,11 @@ type ClientStreamForClient[Req, Res any] struct {
 	err error
 }
 
+// Spec returns the specification for the RPC.
+func (c *ClientStreamForClient[_, _]) Spec() Spec {
+	return c.conn.Spec()
+}
+
 // RequestHeader returns the request headers. Headers are sent to the server with the
 // first call to Send.
 func (c *ClientStreamForClient[Req, Res]) RequestHeader() http.Header {
@@ -162,6 +167,11 @@ type BidiStreamForClient[Req, Res any] struct {
 	conn StreamingClientConn
 	// Error from client construction. If non-nil, return for all calls.
 	err error
+}
+
+// Spec returns the specification for the RPC.
+func (b *BidiStreamForClient[_, _]) Spec() Spec {
+	return b.conn.Spec()
 }
 
 // RequestHeader returns the request headers. Headers are sent with the first

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -1431,6 +1431,9 @@ func (p pingServer) Ping(ctx context.Context, request *connect.Request[pingv1.Pi
 	if err := expectClientHeader(p.checkMetadata, request); err != nil {
 		return nil, err
 	}
+	if request.Peer().Addr == "" {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("no peer address"))
+	}
 	response := connect.NewResponse(
 		&pingv1.PingResponse{
 			Number: request.Msg.Number,
@@ -1446,6 +1449,9 @@ func (p pingServer) Fail(ctx context.Context, request *connect.Request[pingv1.Fa
 	if err := expectClientHeader(p.checkMetadata, request); err != nil {
 		return nil, err
 	}
+	if request.Peer().Addr == "" {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("no peer address"))
+	}
 	err := connect.NewError(connect.Code(request.Msg.Code), errors.New(errorMessage))
 	err.Meta().Set(handlerHeader, headerValue)
 	err.Meta().Set(handlerTrailer, trailerValue)
@@ -1460,6 +1466,9 @@ func (p pingServer) Sum(
 		if err := expectMetadata(stream.RequestHeader(), "header", clientHeader, headerValue); err != nil {
 			return nil, err
 		}
+	}
+	if stream.Peer().Addr == "" {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("no peer address"))
 	}
 	var sum int64
 	for stream.Receive() {
@@ -1481,6 +1490,9 @@ func (p pingServer) CountUp(
 ) error {
 	if err := expectClientHeader(p.checkMetadata, request); err != nil {
 		return err
+	}
+	if request.Peer().Addr == "" {
+		return connect.NewError(connect.CodeInternal, errors.New("no peer address"))
 	}
 	if request.Msg.Number <= 0 {
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf(
@@ -1507,6 +1519,9 @@ func (p pingServer) CumSum(
 		if err := expectMetadata(stream.RequestHeader(), "header", clientHeader, headerValue); err != nil {
 			return err
 		}
+	}
+	if stream.Peer().Addr == "" {
+		return connect.NewError(connect.CodeInternal, errors.New("no peer address"))
 	}
 	stream.ResponseHeader().Set(handlerHeader, headerValue)
 	stream.ResponseTrailer().Set(handlerTrailer, trailerValue)

--- a/handler.go
+++ b/handler.go
@@ -62,6 +62,7 @@ func NewUnaryHandler[Req, Res any](
 		request := &Request[Req]{
 			Msg:    &msg,
 			spec:   conn.Spec(),
+			peer:   conn.Peer(),
 			header: conn.RequestHeader(),
 		}
 		response, err := untyped(ctx, request)
@@ -124,6 +125,7 @@ func NewServerStreamHandler[Req, Res any](
 				&Request[Req]{
 					Msg:    &msg,
 					spec:   conn.Spec(),
+					peer:   conn.Peer(),
 					header: conn.RequestHeader(),
 				},
 				&ServerStream[Res]{conn: conn},

--- a/handler_stream.go
+++ b/handler_stream.go
@@ -35,6 +35,11 @@ func (c *ClientStream[_]) Spec() Spec {
 	return c.conn.Spec()
 }
 
+// Peer describes the client for this RPC.
+func (c *ClientStream[_]) Peer() Peer {
+	return c.conn.Peer()
+}
+
 // RequestHeader returns the headers received from the client.
 func (c *ClientStream[Req]) RequestHeader() http.Header {
 	return c.conn.RequestHeader()
@@ -119,6 +124,11 @@ type BidiStream[Req, Res any] struct {
 // Spec returns the specification for the RPC.
 func (b *BidiStream[_, _]) Spec() Spec {
 	return b.conn.Spec()
+}
+
+// Peer describes the client for this RPC.
+func (b *BidiStream[_, _]) Peer() Peer {
+	return b.conn.Peer()
 }
 
 // RequestHeader returns the headers received from the client.

--- a/handler_stream.go
+++ b/handler_stream.go
@@ -30,6 +30,11 @@ type ClientStream[Req any] struct {
 	err  error
 }
 
+// Spec returns the specification for the RPC.
+func (c *ClientStream[_]) Spec() Spec {
+	return c.conn.Spec()
+}
+
 // RequestHeader returns the headers received from the client.
 func (c *ClientStream[Req]) RequestHeader() http.Header {
 	return c.conn.RequestHeader()
@@ -109,6 +114,11 @@ func (s *ServerStream[Res]) Conn() StreamingHandlerConn {
 // an exported constructor.
 type BidiStream[Req, Res any] struct {
 	conn StreamingHandlerConn
+}
+
+// Spec returns the specification for the RPC.
+func (b *BidiStream[_, _]) Spec() Spec {
+	return b.conn.Spec()
 }
 
 // RequestHeader returns the headers received from the client.

--- a/protocol.go
+++ b/protocol.go
@@ -111,6 +111,9 @@ type protocolClientParams struct {
 // Client is the client side of a protocol. HTTP clients typically use a single
 // protocol, codec, and compressor to send requests.
 type protocolClient interface {
+	// Peer describes the server for the RPC.
+	Peer() Peer
+
 	// WriteRequestHeader writes any protocol-specific request headers.
 	WriteRequestHeader(StreamType, http.Header)
 


### PR DESCRIPTION
On requests and streams, expose the peer's address. For clients, the address is the host or host:port, parsed from the URL. For servers, the address is an IP:port pair, provided by `net/http` as `Request.RemoteAddr`.

In https://github.com/bufbuild/connect-go/issues/357, a handful of users asked for this information for logging, per-IP rate limiting, and a variety of other server-side concerns. It's also necessary for OpenTelemetry interceptors (https://github.com/bufbuild/connect-go/issues/344).

Fixes https://github.com/bufbuild/connect-go/issues/357.