### PR TITLE
Prepare for v1.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,8 +81,9 @@ issues:
     # It should be crystal clear that Connect uses plain *http.Clients.
     - linters: [revive, stylecheck]
       path: client_example_test.go
-    # Doesn't work with type parameters.
-    # TODO: re-enable when working.
-    - linters:
-        - revive
-      text: "receiver-naming:.*for invalid-type$"
+    # Don't complain about timeout management or lack of output assertions in examples.
+    - linters: [gosec, testableexamples]
+      path: handler_example_test.go
+    # No output assertions needed for these examples.
+    - linters: [testableexamples]
+      path: error_writer_example_test.go

--- a/Makefile
+++ b/Makefile
@@ -84,16 +84,16 @@ $(BIN)/protoc-gen-connect-go:
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.7.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.8.0
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.7.0
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.8.0
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/README.md
+++ b/README.md
@@ -147,25 +147,20 @@ configuring timeouts, connection pools, observability, and h2c.
 
 * [connect-grpchealth-go]: gRPC-compatible health checks
 * [connect-grpcreflect-go]: gRPC-compatible server reflection
-* [connect-demo]: demonstration service powering demo.connect.build, including bidi streaming
+* [connect-demo]: service powering demo.connect.build, including bidi streaming
 * [connect-web]: TypeScript clients for web browsers
 * [Buf Studio]: web UI for ad-hoc RPCs
 * [connect-crosstest]: gRPC and gRPC-Web interoperability tests
 
-## Status
+## Status: Stable
 
-This module is a beta: we rely on it in production, but we may make a few
-changes as we gather feedback from early adopters. We're planning to tag a
-stable v1 in October, soon after the Go 1.19 release.
-
-## Support and versioning
-
-`connect-go` supports:
+This module is stable. It supports:
 
 * The [two most recent major releases][go-support-policy] of Go.
 * [APIv2] of Protocol Buffers in Go (`google.golang.org/protobuf`).
 
-Within those parameters, Connect follows semantic versioning.
+Within those parameters, `connect-go` follows semantic versioning. We will
+_not_ make breaking changes in the 1.x series of releases.
 
 ## Legal
 

--- a/connect.go
+++ b/connect.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "0.4.0-dev"
+const Version = "1.0.0"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/bufbuild/connect-go
 go 1.18
 
 require (
-	github.com/google/go-cmp v0.5.8
+	github.com/google/go-cmp v0.5.9
 	google.golang.org/protobuf v1.28.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=

--- a/handler.go
+++ b/handler.go
@@ -189,8 +189,8 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 	}
 
 	// Establish a stream and serve the RPC.
-	request.Header.Set("Content-Type", contentType) // prefer canonicalized value
-	ctx, cancel, timeoutErr := protocolHandler.SetTimeout(request)
+	request.Header.Set("Content-Type", contentType)                // prefer canonicalized value
+	ctx, cancel, timeoutErr := protocolHandler.SetTimeout(request) //nolint: contextcheck
 	if timeoutErr != nil {
 		ctx = request.Context()
 	}


### PR DESCRIPTION
We've done enough with OpenTelemetry and client-side load-balancing to be
comfortable, so there's little benefit to holding off. Let's commit to a stable
release!
