### PR TITLE
Rename IsWireErr -> IsWireError

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -238,7 +238,7 @@ func TestServer(t *testing.T) {
 			// error.
 			_, err := stream.Receive()
 			assert.Equal(t, connect.CodeOf(err), connect.CodeInvalidArgument)
-			assert.True(t, connect.IsWireErr(err))
+			assert.True(t, connect.IsWireError(err))
 		})
 		t.Run("cumsum_empty_stream", func(t *testing.T) {
 			stream := client.CumSum(context.Background())
@@ -253,7 +253,7 @@ func TestServer(t *testing.T) {
 			response, err := stream.Receive()
 			assert.Nil(t, response)
 			assert.True(t, errors.Is(err, io.EOF))
-			assert.False(t, connect.IsWireErr(err))
+			assert.False(t, connect.IsWireError(err))
 			assert.Nil(t, stream.CloseResponse()) // clean-up the stream
 		})
 		t.Run("cumsum_cancel_after_first_response", func(t *testing.T) {
@@ -278,7 +278,7 @@ func TestServer(t *testing.T) {
 			_, err = stream.Receive()
 			assert.Equal(t, connect.CodeOf(err), connect.CodeCanceled)
 			assert.Equal(t, got, expect)
-			assert.False(t, connect.IsWireErr(err))
+			assert.False(t, connect.IsWireError(err))
 		})
 		t.Run("cumsum_cancel_before_send", func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -290,7 +290,7 @@ func TestServer(t *testing.T) {
 			// cancellations.
 			err := stream.Send(&pingv1.CumSumRequest{Number: 19})
 			assert.Equal(t, connect.CodeOf(err), connect.CodeCanceled, assert.Sprintf("%v", err))
-			assert.False(t, connect.IsWireErr(err))
+			assert.False(t, connect.IsWireError(err))
 		})
 	}
 	testErrors := func(t *testing.T, client pingv1connect.PingServiceClient) { //nolint:thelper
@@ -319,7 +319,7 @@ func TestServer(t *testing.T) {
 			var connectErr *connect.Error
 			ok := errors.As(err, &connectErr)
 			assert.True(t, ok, assert.Sprintf("conversion to *connect.Error"))
-			assert.True(t, connect.IsWireErr(err))
+			assert.True(t, connect.IsWireError(err))
 			assert.Equal(t, connectErr.Code(), connect.CodeResourceExhausted)
 			assert.Equal(t, connectErr.Error(), "resource_exhausted: "+errorMessage)
 			assert.Zero(t, connectErr.Details())

--- a/error.go
+++ b/error.go
@@ -112,8 +112,13 @@ func NewError(c Code, underlying error) *Error {
 	return &Error{code: c, err: underlying}
 }
 
-// IsWireErr returns true if the error was produced by the server.
-func IsWireErr(err error) bool {
+// IsWireError checks whether the error was returned by the server, as opposed
+// to being synthesized by the client.
+//
+// Clients may find this useful when deciding how to propagate errors. For
+// example, an RPC-to-HTTP proxy might expose a server-sent CodeUnknown as an
+// HTTP 500 but a client-synthesized CodeUnknown as a 503.
+func IsWireError(err error) bool {
 	se := new(Error)
 	if !errors.As(err, &se) {
 		return false


### PR DESCRIPTION
`connect-go` doesn't typically shorten "error" to "err" in exported
APIs. (For example, we have `ErrorWriter` instead of `ErrWriter`.)
Rename `IsWireErr` to match, and add some more GoDoc to motivate usage.
