### PR TITLE
Update Github Actions outputs to new format

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -28,7 +28,7 @@ jobs:
       - id: go-cache-paths
         shell: bash
         run: |
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Mod Cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
