### PR TITLE
Fix panic on zero send from server

### DIFF
--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/bufbuild/connect-go"
@@ -131,110 +130,6 @@ func TestClientPeer(t *testing.T) {
 	t.Run("grpcweb", func(t *testing.T) {
 		t.Parallel()
 		run(t, connect.WithGRPCWeb())
-	})
-}
-
-func TestConnectHTTPErrorCodes(t *testing.T) {
-	t.Parallel()
-	checkHTTPStatus := func(t *testing.T, connectCode connect.Code, wantHttpStatus int) {
-		t.Helper()
-		mux := http.NewServeMux()
-		pluggableServer := &pluggablePingServer{
-			ping: func(_ context.Context, _ *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
-				return nil, connect.NewError(connectCode, errors.New("error"))
-			},
-		}
-		mux.Handle(pingv1connect.NewPingServiceHandler(pluggableServer))
-		server := httptest.NewServer(mux)
-		t.Cleanup(server.Close)
-		req, err := http.NewRequestWithContext(
-			context.Background(),
-			http.MethodPost,
-			server.URL+"/"+pingv1connect.PingServiceName+"/Ping",
-			strings.NewReader("{}"),
-		)
-		assert.Nil(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := server.Client().Do(req)
-		assert.Nil(t, err)
-		assert.Equal(t, wantHttpStatus, resp.StatusCode)
-		defer resp.Body.Close()
-		connectClient := pingv1connect.NewPingServiceClient(server.Client(), server.URL)
-		connectResp, err := connectClient.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{}))
-		assert.NotNil(t, err)
-		assert.Nil(t, connectResp)
-	}
-	t.Run("CodeCanceled-408", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeCanceled, 408)
-	})
-	t.Run("CodeUnknown-500", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeUnknown, 500)
-	})
-	t.Run("CodeInvalidArgument-400", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeInvalidArgument, 400)
-	})
-	t.Run("CodeDeadlineExceeded-408", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeDeadlineExceeded, 408)
-	})
-	t.Run("CodeNotFound-404", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeNotFound, 404)
-	})
-	t.Run("CodeAlreadyExists-409", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeAlreadyExists, 409)
-	})
-	t.Run("CodePermissionDenied-403", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodePermissionDenied, 403)
-	})
-	t.Run("CodeResourceExhausted-429", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeResourceExhausted, 429)
-	})
-	t.Run("CodeFailedPrecondition-412", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeFailedPrecondition, 412)
-	})
-	t.Run("CodeAborted-409", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeAborted, 409)
-	})
-	t.Run("CodeOutOfRange-400", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeOutOfRange, 400)
-	})
-	t.Run("CodeUnimplemented-404", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeUnimplemented, 404)
-	})
-	t.Run("CodeInternal-500", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeInternal, 500)
-	})
-	t.Run("CodeUnavailable-503", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeUnavailable, 503)
-	})
-	t.Run("CodeDataLoss-500", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeDataLoss, 500)
-	})
-	t.Run("CodeUnauthenticated-401", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, connect.CodeUnauthenticated, 401)
-	})
-	t.Run("100-500", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, 100, 500)
-	})
-	t.Run("0-500", func(t *testing.T) {
-		t.Parallel()
-		checkHTTPStatus(t, 0, 500)
 	})
 }
 

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -1661,85 +1661,85 @@ func TestConnectHTTPErrorCodes(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := server.Client().Do(req)
 		assert.Nil(t, err)
-		assert.Equal(t, wantHttpStatus, resp.StatusCode)
 		defer resp.Body.Close()
+		assert.Equal(t, wantHttpStatus, resp.StatusCode)
 		connectClient := pingv1connect.NewPingServiceClient(server.Client(), server.URL)
 		connectResp, err := connectClient.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{}))
 		assert.NotNil(t, err)
 		assert.Nil(t, connectResp)
 	}
-	t.Run("connect.CodeCanceled, 408", func(t *testing.T) {
+	t.Run("CodeCanceled-408", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeCanceled, 408)
 	})
-	t.Run("connect.CodeUnknown, 500", func(t *testing.T) {
+	t.Run("CodeUnknown-500", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeUnknown, 500)
 	})
-	t.Run("connect.CodeInvalidArgument, 400", func(t *testing.T) {
+	t.Run("CodeInvalidArgument-400", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeInvalidArgument, 400)
 	})
-	t.Run("connect.CodeDeadlineExceeded, 408", func(t *testing.T) {
+	t.Run("CodeDeadlineExceeded-408", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeDeadlineExceeded, 408)
 	})
-	t.Run("connect.CodeNotFound, 404", func(t *testing.T) {
+	t.Run("CodeNotFound-404", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeNotFound, 404)
 	})
-	t.Run("connect.CodeAlreadyExists, 409", func(t *testing.T) {
+	t.Run("CodeAlreadyExists-409", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeAlreadyExists, 409)
 	})
-	t.Run("connect.CodePermissionDenied, 403", func(t *testing.T) {
+	t.Run("CodePermissionDenied-403", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodePermissionDenied, 403)
 	})
-	t.Run("connect.CodeResourceExhausted, 429", func(t *testing.T) {
+	t.Run("CodeResourceExhausted-429", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeResourceExhausted, 429)
 	})
-	t.Run("connect.CodeFailedPrecondition, 412", func(t *testing.T) {
+	t.Run("CodeFailedPrecondition-412", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeFailedPrecondition, 412)
 	})
-	t.Run("connect.CodeAborted, 409", func(t *testing.T) {
+	t.Run("CodeAborted-409", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeAborted, 409)
 	})
-	t.Run("connect.CodeOutOfRange, 400", func(t *testing.T) {
+	t.Run("CodeOutOfRange-400", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeOutOfRange, 400)
 	})
-	t.Run("connect.CodeUnimplemented, 404", func(t *testing.T) {
+	t.Run("CodeUnimplemented-404", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeUnimplemented, 404)
 	})
-	t.Run("connect.CodeInternal, 500", func(t *testing.T) {
+	t.Run("CodeInternal-500", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeInternal, 500)
 	})
-	t.Run("connect.CodeUnavailable, 503", func(t *testing.T) {
+	t.Run("CodeUnavailable-503", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeUnavailable, 503)
 	})
-	t.Run("connect.CodeDataLoss, 500", func(t *testing.T) {
+	t.Run("CodeDataLoss-500", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeDataLoss, 500)
 	})
-	t.Run("connect.CodeUnauthenticated, 401", func(t *testing.T) {
+	t.Run("CodeUnauthenticated-401", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeUnauthenticated, 401)
 	})
-	t.Run("100, 500", func(t *testing.T) {
+	t.Run("100-500", func(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, 100, 500)
 	})
-	// t.Run("0, 500", func(t *testing.T) { //TODO: enable this when
-	//	t.Parallel()
-	//	checkHTTPStatus(t, 0, 500)
-	// })
+	t.Run("0-500", func(t *testing.T) {
+		t.Parallel()
+		checkHTTPStatus(t, 0, 500)
+	})
 }
 
 func TestFailCompression(t *testing.T) {

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -925,7 +925,7 @@ func (e *connectWireError) asError() *Error {
 	if e == nil {
 		return nil
 	}
-	if e.Code == 0 {
+	if e.Code < minCode || e.Code > maxCode {
 		e.Code = CodeUnknown
 	}
 	err := NewError(e.Code, errors.New(e.Message))

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -423,6 +423,9 @@ func (cc *connectUnaryClientConn) validateResponse(response *http.Response) *Err
 			)
 		}
 		serverErr := wireErr.asError()
+		if serverErr == nil {
+			return nil
+		}
 		serverErr.meta = cc.responseHeader.Clone()
 		mergeHeaders(serverErr.meta, cc.responseTrailer)
 		return serverErr
@@ -919,8 +922,11 @@ func newConnectWireError(err error) *connectWireError {
 }
 
 func (e *connectWireError) asError() *Error {
-	if e == nil || e.Code == 0 {
+	if e == nil {
 		return nil
+	}
+	if e.Code == 0 {
+		e.Code = CodeUnknown
 	}
 	err := NewError(e.Code, errors.New(e.Message))
 	err.wireErr = true


### PR DESCRIPTION
- Maps a zero code of `connectWireError` to a CodeUnknown in `connectWireError) asError() *Error `
This could have been done in the unmarshaling to `connectWireError` but I chose to leave that to be exactly what was read off the wire. 
- Adds nil guard in `validateResponse` for asError
- Adds tests for error mapping

Fixes: https://github.com/bufbuild/connect-go/issues/396
