### PR TITLE
Format imports with GCI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters:
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
+    - goimports         # rely on gci instead
     - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
     - ifshort           # deprecated by author


### PR DESCRIPTION
`golangci-lint` includes `gci` by default, so we can disable `goimports`. The auto-fix function still works, so `make lintfix` is enough to reformat any files with incorrectly grouped imports.