### PR TITLE
Close conn when HTTP/1.1 clients call bidi methods

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -162,6 +162,10 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 	// okay if we can't re-use the connection.
 	isBidi := (h.spec.StreamType & StreamTypeBidi) == StreamTypeBidi
 	if isBidi && request.ProtoMajor < 2 {
+		// Clients coded to expect full-duplex connections may hang if they've
+		// mistakenly negotiated HTTP/1.1. To unblock them, we must close the
+		// underlying TCP connection.
+		responseWriter.Header().Set("Connection", "close")
 		responseWriter.WriteHeader(http.StatusHTTPVersionNotSupported)
 		return
 	}


### PR DESCRIPTION
If an HTTP/1.1 client calls a bidi RPC method, the caller has likely written application-level code that expects a full-duplex stream. Unless the server closes the TCP connection, the client code will often end up blocked because it's trying to read the response before it closes the request body.
