### PR TITLE
add API to make it easier to work with ErrorDetail if you have/want an Any

### DIFF
--- a/error.go
+++ b/error.go
@@ -44,8 +44,9 @@ type ErrorDetail struct {
 	wireJSON string // preserve human-readable JSON
 }
 
-// NewErrorDetail constructs a new error detail. This returns an error
-// if msg cannot be marshalled into an Any message.
+// NewErrorDetail constructs a new error detail. If msg is an *[anypb.Any] then
+// it is used as is. Otherwise, it is first marshaleled into an *[anypb.Any]
+// value. This returns an error if msg cannot be marshalled.
 func NewErrorDetail(msg proto.Message) (*ErrorDetail, error) {
 	// If it's already an Any, don't wrap it inside another.
 	if pb, ok := msg.(*anypb.Any); ok {

--- a/error.go
+++ b/error.go
@@ -47,17 +47,15 @@ type ErrorDetail struct {
 // NewErrorDetail constructs a new error detail. This returns an error
 // if msg cannot be marshalled into an Any message.
 func NewErrorDetail(msg proto.Message) (*ErrorDetail, error) {
+	// If it's already an Any, don't wrap it inside another.
+	if pb, ok := msg.(*anypb.Any); ok {
+		return &ErrorDetail{pb: pb}, nil
+	}
 	pb, err := anypb.New(msg)
 	if err != nil {
 		return nil, err
 	}
 	return &ErrorDetail{pb: pb}, nil
-}
-
-// NewErrorDetailFromAny constructs a new error detail using the
-// given Any message.
-func NewErrorDetailFromAny(pb *anypb.Any) *ErrorDetail {
-	return &ErrorDetail{pb: pb}
 }
 
 // Type is the fully-qualified name of the detail's Protobuf message (for
@@ -86,11 +84,6 @@ func (d *ErrorDetail) Bytes() []byte {
 // assertions to cast from the proto.Message interface to concrete types.
 func (d *ErrorDetail) Value() (proto.Message, error) {
 	return d.pb.UnmarshalNew()
-}
-
-// Any returns the underlying Any message for this error detail.
-func (d *ErrorDetail) Any() *anypb.Any {
-	return d.pb
 }
 
 // An Error captures four key pieces of information: a [Code], an underlying Go

--- a/error.go
+++ b/error.go
@@ -44,13 +44,20 @@ type ErrorDetail struct {
 	wireJSON string // preserve human-readable JSON
 }
 
-// NewErrorDetail constructs a new error detail.
+// NewErrorDetail constructs a new error detail. This returns an error
+// if msg cannot be marshalled into an Any message.
 func NewErrorDetail(msg proto.Message) (*ErrorDetail, error) {
 	pb, err := anypb.New(msg)
 	if err != nil {
 		return nil, err
 	}
 	return &ErrorDetail{pb: pb}, nil
+}
+
+// NewErrorDetailFromAny constructs a new error detail using the
+// given Any message.
+func NewErrorDetailFromAny(pb *anypb.Any) *ErrorDetail {
+	return &ErrorDetail{pb: pb}
 }
 
 // Type is the fully-qualified name of the detail's Protobuf message (for
@@ -79,6 +86,11 @@ func (d *ErrorDetail) Bytes() []byte {
 // assertions to cast from the proto.Message interface to concrete types.
 func (d *ErrorDetail) Value() (proto.Message, error) {
 	return d.pb.UnmarshalNew()
+}
+
+// Any returns the underlying Any message for this error detail.
+func (d *ErrorDetail) Any() *anypb.Any {
+	return d.pb
 }
 
 // An Error captures four key pieces of information: a [Code], an underlying Go

--- a/error.go
+++ b/error.go
@@ -45,7 +45,7 @@ type ErrorDetail struct {
 }
 
 // NewErrorDetail constructs a new error detail. If msg is an *[anypb.Any] then
-// it is used as is. Otherwise, it is first marshaleled into an *[anypb.Any]
+// it is used as is. Otherwise, it is first marshalled into an *[anypb.Any]
 // value. This returns an error if msg cannot be marshalled.
 func NewErrorDetail(msg proto.Message) (*ErrorDetail, error) {
 	// If it's already an Any, don't wrap it inside another.


### PR DESCRIPTION
If your code already has an instance of `Any`, it's a pain (and not even guaranteed to be possible at runtime!) to unmarshal the message therein only to re-wrap it in order to put it in an `ErrorDetail`.

Similarly, if you can't unmarshal the contained type, it may be useful to access the `Any` envelope.

This adds two new APIs for just this.