### PR TITLE
Expose *http.Request to server Peer

### DIFF
--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -116,7 +116,7 @@ func TestClientPeer(t *testing.T) {
 		})
 		assert.NotZero(t, bidiStream.Peer().Addr)
 		assert.NotZero(t, bidiStream.Peer().Protocol)
-		assert.Nil(t, clientStream.Peer().Request)
+		assert.Nil(t, bidiStream.Peer().Request)
 		err = bidiStream.Send(&pingv1.CumSumRequest{})
 		assert.Nil(t, err)
 	}

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -99,6 +99,7 @@ func TestClientPeer(t *testing.T) {
 		})
 		assert.NotZero(t, clientStream.Peer().Addr)
 		assert.NotZero(t, clientStream.Peer().Protocol)
+		assert.Nil(t, clientStream.Peer().Request)
 		err = clientStream.Send(&pingv1.SumRequest{})
 		assert.Nil(t, err)
 		// server streaming
@@ -115,6 +116,7 @@ func TestClientPeer(t *testing.T) {
 		})
 		assert.NotZero(t, bidiStream.Peer().Addr)
 		assert.NotZero(t, bidiStream.Peer().Protocol)
+		assert.Nil(t, clientStream.Peer().Request)
 		err = bidiStream.Send(&pingv1.CumSumRequest{})
 		assert.Nil(t, err)
 	}
@@ -141,6 +143,7 @@ func (a *assertPeerInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryF
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		assert.NotZero(a.tb, req.Peer().Addr)
 		assert.NotZero(a.tb, req.Peer().Protocol)
+		assert.Nil(a.tb, req.Peer().Request)
 		return next(ctx, req)
 	}
 }
@@ -150,6 +153,7 @@ func (a *assertPeerInterceptor) WrapStreamingClient(next connect.StreamingClient
 		conn := next(ctx, spec)
 		assert.NotZero(a.tb, conn.Peer().Addr)
 		assert.NotZero(a.tb, conn.Peer().Protocol)
+		assert.Nil(a.tb, conn.Peer().Request)
 		assert.NotZero(a.tb, conn.Spec())
 		return conn
 	}
@@ -159,6 +163,7 @@ func (a *assertPeerInterceptor) WrapStreamingHandler(next connect.StreamingHandl
 	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
 		assert.NotZero(a.tb, conn.Peer().Addr)
 		assert.NotZero(a.tb, conn.Peer().Protocol)
+		assert.Nil(a.tb, conn.Peer().Request)
 		assert.NotZero(a.tb, conn.Spec())
 		return next(ctx, conn)
 	}

--- a/connect.go
+++ b/connect.go
@@ -262,12 +262,16 @@ type Spec struct {
 // On both the client and the server, Protocol is the RPC protocol in use.
 // Currently, it's either [ProtocolConnect], [ProtocolGRPC], or
 // [ProtocolGRPCWeb], but additional protocols may be added in the future.
+//
+// On server, Request is the HTTP request that initiated the RPC,
+// on client, Request is nil.
 type Peer struct {
 	Addr     string
 	Protocol string
+	Request  *http.Request
 }
 
-func newPeerFromURL(urlString, protocol string) Peer {
+func newClientPeerFromURL(urlString, protocol string) Peer {
 	peer := Peer{Protocol: protocol}
 	if u, err := url.Parse(urlString); err == nil {
 		peer.Addr = u.Host

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -167,6 +167,7 @@ func (h *connectHandler) NewConn(
 	peer := Peer{
 		Addr:     request.RemoteAddr,
 		Protocol: ProtocolConnect,
+		Request:  request,
 	}
 	if h.Spec.StreamType == StreamTypeUnary {
 		conn = &connectUnaryHandlerConn{
@@ -236,7 +237,7 @@ type connectClient struct {
 }
 
 func (c *connectClient) Peer() Peer {
-	return newPeerFromURL(c.URL, ProtocolConnect)
+	return newClientPeerFromURL(c.URL, ProtocolConnect)
 }
 
 func (c *connectClient) WriteRequestHeader(streamType StreamType, header http.Header) {

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -173,6 +173,7 @@ func (g *grpcHandler) NewConn(
 		peer: Peer{
 			Addr:     request.RemoteAddr,
 			Protocol: protocolName,
+			Request:  request,
 		},
 		web:        g.web,
 		bufferPool: g.BufferPool,
@@ -218,9 +219,9 @@ type grpcClient struct {
 
 func (g *grpcClient) Peer() Peer {
 	if g.web {
-		return newPeerFromURL(g.URL, ProtocolGRPCWeb)
+		return newClientPeerFromURL(g.URL, ProtocolGRPCWeb)
 	}
-	return newPeerFromURL(g.URL, ProtocolGRPC)
+	return newClientPeerFromURL(g.URL, ProtocolGRPC)
 }
 
 func (g *grpcClient) WriteRequestHeader(_ StreamType, header http.Header) {


### PR DESCRIPTION
In some cases, we need access to the underlying *http.Request in the handler.

For example, we need access to the underlying request.TLS to identify peer identity.