### PR TITLE
Don't clobber custom User-Agents

### DIFF
--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -242,7 +242,9 @@ func (c *connectClient) Peer() Peer {
 func (c *connectClient) WriteRequestHeader(streamType StreamType, header http.Header) {
 	// We know these header keys are in canonical form, so we can bypass all the
 	// checks in Header.Set.
-	header[headerUserAgent] = []string{connectUserAgent()}
+	if header.Get(headerUserAgent) == "" {
+		header[headerUserAgent] = []string{connectUserAgent()}
+	}
 	header[connectHeaderProtocolVersion] = []string{connectProtocolVersion}
 	header[headerContentType] = []string{
 		connectContentTypeFromCodecName(streamType, c.Codec.Name()),

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -226,7 +226,9 @@ func (g *grpcClient) Peer() Peer {
 func (g *grpcClient) WriteRequestHeader(_ StreamType, header http.Header) {
 	// We know these header keys are in canonical form, so we can bypass all the
 	// checks in Header.Set.
-	header[headerUserAgent] = []string{grpcUserAgent()}
+	if header.Get(headerUserAgent) == "" {
+		header[headerUserAgent] = []string{grpcUserAgent()}
+	}
 	header[headerContentType] = []string{grpcContentTypeFromCodecName(g.web, g.Codec.Name())}
 	// gRPC handles compression on a per-message basis, so we don't want to
 	// compress the whole stream. By default, http.Client will ask the server


### PR DESCRIPTION
If the caller sets a User-Agent manually, we shouldn't clobber it. This
should unblock some internal use cases where people want to use
User-Agents to identify internal services, environments, etc.
