### PR TITLE
Document reserved headers more prominently

### DIFF
--- a/client_stream.go
+++ b/client_stream.go
@@ -42,6 +42,9 @@ func (c *ClientStreamForClient[_, _]) Peer() Peer {
 
 // RequestHeader returns the request headers. Headers are sent to the server with the
 // first call to Send.
+//
+// Headers beginning with "Connect-" and "Grpc-" are reserved for use by the
+// Connect and gRPC protocols. Applications shouldn't write them.
 func (c *ClientStreamForClient[Req, Res]) RequestHeader() http.Header {
 	if c.err != nil {
 		return http.Header{}
@@ -189,6 +192,9 @@ func (b *BidiStreamForClient[_, _]) Peer() Peer {
 
 // RequestHeader returns the request headers. Headers are sent with the first
 // call to Send.
+//
+// Headers beginning with "Connect-" and "Grpc-" are reserved for use by the
+// Connect and gRPC protocols. Applications shouldn't write them.
 func (b *BidiStreamForClient[Req, Res]) RequestHeader() http.Header {
 	if b.err != nil {
 		return http.Header{}

--- a/connect.go
+++ b/connect.go
@@ -62,6 +62,10 @@ const (
 // Receive returns an error wrapping [io.EOF]. Handlers should check for this
 // using the standard library's [errors.Is].
 //
+// Headers and trailers beginning with "Connect-" and "Grpc-" are reserved for
+// use by the gRPC and Connect protocols: applications may read them but
+// shouldn't write them.
+//
 // StreamingHandlerConn implementations provided by this module guarantee that
 // all returned errors can be cast to [*Error] using the standard library's
 // [errors.As].
@@ -90,6 +94,10 @@ type StreamingHandlerConn interface {
 // processing, subsequent calls to the StreamingClientConn's Send method will
 // return an error wrapping [io.EOF]; clients may then call Receive to unmarshal
 // the error.
+//
+// Headers and trailers beginning with "Connect-" and "Grpc-" are reserved for
+// use by the gRPC and Connect protocols: applications may read them but
+// shouldn't write them.
 //
 // StreamingClientConn implementations provided by this module guarantee that
 // all returned errors can be cast to [*Error] using the standard library's
@@ -153,7 +161,9 @@ func (r *Request[_]) Peer() Peer {
 	return r.peer
 }
 
-// Header returns the HTTP headers for this request.
+// Header returns the HTTP headers for this request. Headers beginning with
+// "Connect-" and "Grpc-" are reserved for use by the Connect and gRPC
+// protocols: applications may read them but shouldn't write them.
 func (r *Request[_]) Header() http.Header {
 	if r.header == nil {
 		r.header = make(http.Header)
@@ -166,6 +176,10 @@ func (r *Request[_]) internalOnly() {}
 
 // AnyRequest is the common method set of every [Request], regardless of type
 // parameter. It's used in unary interceptors.
+//
+// Headers and trailers beginning with "Connect-" and "Grpc-" are reserved for
+// use by the gRPC and Connect protocols: applications may read them but
+// shouldn't write them.
 //
 // To preserve our ability to add methods to this interface without breaking
 // backward compatibility, only types defined in this package can implement
@@ -205,7 +219,9 @@ func (r *Response[_]) Any() any {
 	return r.Msg
 }
 
-// Header returns the HTTP headers for this response.
+// Header returns the HTTP headers for this response. Headers beginning with
+// "Connect-" and "Grpc-" are reserved for use by the Connect and gRPC
+// protocols: applications may read them but shouldn't write them.
 func (r *Response[_]) Header() http.Header {
 	if r.header == nil {
 		r.header = make(http.Header)
@@ -216,6 +232,10 @@ func (r *Response[_]) Header() http.Header {
 // Trailer returns the trailers for this response. Depending on the underlying
 // RPC protocol, trailers may be sent as HTTP trailers or a protocol-specific
 // block of in-body metadata.
+//
+// Trailers beginning with "Connect-" and "Grpc-" are reserved for use by the
+// Connect and gRPC protocols: applications may read them but shouldn't write
+// them.
 func (r *Response[_]) Trailer() http.Header {
 	if r.trailer == nil {
 		r.trailer = make(http.Header)
@@ -228,6 +248,10 @@ func (r *Response[_]) internalOnly() {}
 
 // AnyResponse is the common method set of every [Response], regardless of type
 // parameter. It's used in unary interceptors.
+//
+// Headers and trailers beginning with "Connect-" and "Grpc-" are reserved for
+// use by the gRPC and Connect protocols: applications may read them but
+// shouldn't write them.
 //
 // To preserve our ability to add methods to this interface without breaking
 // backward compatibility, only types defined in this package can implement

--- a/handler_stream.go
+++ b/handler_stream.go
@@ -91,12 +91,18 @@ type ServerStream[Res any] struct {
 
 // ResponseHeader returns the response headers. Headers are sent with the first
 // call to Send.
+//
+// Headers beginning with "Connect-" and "Grpc-" are reserved for use by the
+// Connect and gRPC protocols. Applications shouldn't write them.
 func (s *ServerStream[Res]) ResponseHeader() http.Header {
 	return s.conn.ResponseHeader()
 }
 
 // ResponseTrailer returns the response trailers. Handlers may write to the
 // response trailers at any time before returning.
+//
+// Trailers beginning with "Connect-" and "Grpc-" are reserved for use by the
+// Connect and gRPC protocols. Applications shouldn't write them.
 func (s *ServerStream[Res]) ResponseTrailer() http.Header {
 	return s.conn.ResponseTrailer()
 }
@@ -151,12 +157,18 @@ func (b *BidiStream[Req, Res]) Receive() (*Req, error) {
 
 // ResponseHeader returns the response headers. Headers are sent with the first
 // call to Send.
+//
+// Headers beginning with "Connect-" and "Grpc-" are reserved for use by the
+// Connect and gRPC protocols. Applications shouldn't write them.
 func (b *BidiStream[Req, Res]) ResponseHeader() http.Header {
 	return b.conn.ResponseHeader()
 }
 
 // ResponseTrailer returns the response trailers. Handlers may write to the
 // response trailers at any time before returning.
+//
+// Trailers beginning with "Connect-" and "Grpc-" are reserved for use by the
+// Connect and gRPC protocols. Applications shouldn't write them.
 func (b *BidiStream[Req, Res]) ResponseTrailer() http.Header {
 	return b.conn.ResponseTrailer()
 }


### PR DESCRIPTION
On all applicable types and methods, explicitly document that headers
and trailers beginning with "Connect-" and "Grpc-" are reserved for use
by the RPC protocols.

This gets pretty repetitive. We could instead add a section to the
package-level docs, but my impression is that most people only read the
GoDoc for the methods/types they're interested in (so repeating
ourselves is more likely to work).

Relates to the discussion on #430.
