### PR TITLE
Allow handlers to implement a simpler interface

### DIFF
--- a/internal/gen/connect/import/v1/importv1connect/import.connect.go
+++ b/internal/gen/connect/import/v1/importv1connect/import.connect.go
@@ -73,3 +73,16 @@ func NewImportServiceHandler(svc ImportServiceHandler, opts ...connect_go.Handle
 
 // UnimplementedImportServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedImportServiceHandler struct{}
+
+// WrapImportServiceHandler wraps a stripped-down implementation of the service, adapting it to
+// implement the full ImportServiceHandler interface. The stripped-down interface includes only
+// unary methods and doesn't have access to HTTP headers, trailers, or other metadata. The full
+// implementation returns CodeUnimplemented from all streaming methods.
+func WrapImportServiceHandler(simple interface {
+}) ImportServiceHandler {
+	return &wrappedImportServiceHandler{}
+}
+
+type wrappedImportServiceHandler struct {
+	UnimplementedImportServiceHandler
+}


### PR DESCRIPTION
This PR resurrects a simpler version of [a feature we had earlier in `connect-go` development](https://github.com/bufbuild/connect-go/blob/fa11ba1c45213d5f716eec92af4a019b38f766af/internal/gen/proto/go-rerpc/rerpc/ping/v1test/ping_rerpc.pb.go#L357): it lets handlers that don't need access to headers or trailers implement a simpler interface (without the generic `connect.Request` or `connect.Response` structs). For unary methods, the simpler interface matches `grpc-go`'s generated code.

This came up in https://github.com/bufbuild/connect-go/discussions/421. The argument isn't primarily ergonomics or ease of migration, but that the business logic in a [hexagonal architecture](https://8thlight.com/insights/a-color-coded-guide-to-ports-and-adapters)-style application shouldn't be visibly coupled to `connect-go`.

For now, I've just implemented a proof of concept for handlers. If we actually move forward with this, we'd want something similar for clients. Looking at this code, I still feel that this doesn't belong in `protoc-gen-connect-go` - I'd rather have a completely separate plugin that works with these stripped-down interfaces. We'd probaby start with something community-supported instead of putting another binary into this repo.

@bufdev and @joshcarp, what do you think?