### PR TITLE
Prepare for v1.5.0

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.5.0-dev"
+const Version = "1.5.0"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
We've got two notable changes merged and unreleased: adding `NewWireError` and making our charset matching case-insensitive. The former change adds new APIs, so we should bump the minor version number.