### PR TITLE
Minimize allocations parsing Content-Type

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -315,7 +315,7 @@ func flushResponseWriter(w http.ResponseWriter) {
 	}
 }
 
-func canonicalizeContentType(ct string) string {
+func canonicalizeContentType(contentType string) string {
 	// Typically, clients send Content-Type in canonical form, without
 	// parameters. In those cases, we'd like to avoid parsing and
 	// canonicalization overhead.
@@ -323,26 +323,26 @@ func canonicalizeContentType(ct string) string {
 	// See https://www.rfc-editor.org/rfc/rfc2045.html#section-5.1 for a full
 	// grammar.
 	var slashes int
-	for _, r := range ct {
+	for _, r := range contentType {
 		switch {
 		case r >= 'a' && r <= 'z':
 		case r == '.' || r == '+' || r == '-':
 		case r == '/':
 			slashes++
 		default:
-			return canonicalizeContentTypeSlow(ct)
+			return canonicalizeContentTypeSlow(contentType)
 		}
 	}
 	if slashes == 1 {
-		return ct
+		return contentType
 	}
-	return canonicalizeContentTypeSlow(ct)
+	return canonicalizeContentTypeSlow(contentType)
 }
 
-func canonicalizeContentTypeSlow(ct string) string {
-	base, params, err := mime.ParseMediaType(ct)
+func canonicalizeContentTypeSlow(contentType string) string {
+	base, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		return ct
+		return contentType
 	}
 	// According to RFC 9110 Section 8.3.2, the charset parameter value should be treated as case-insensitive.
 	// mime.FormatMediaType canonicalizes parameter names, but not parameter values,

--- a/protocol.go
+++ b/protocol.go
@@ -325,7 +325,6 @@ func canonicalizeContentType(ct string) string {
 	var slashes int
 	for _, r := range ct {
 		switch {
-		case r >= 'A' && r <= 'Z':
 		case r >= 'a' && r <= 'z':
 		case r == '.' || r == '+' || r == '-':
 		case r == '/':

--- a/protocol.go
+++ b/protocol.go
@@ -321,6 +321,10 @@ func canonicalizeContentType(ct string) string {
 		return ct
 	}
 
+	if len(params) == 0 {
+		return base
+	}
+
 	// According to RFC 9110 Section 8.3.2, the charset parameter value should be treated as case-insensitive.
 	// mime.FormatMediaType canonicalizes parameter names, but not parameter values,
 	// because the case sensitivity of a parameter value depends on its semantics.

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -27,6 +27,7 @@ func TestCanonicalizeContentType(t *testing.T) {
 		arg  string
 		want string
 	}{
+		{name: "uppercase should be normalized", arg: "APPLICATION/json", want: "application/json"},
 		{name: "charset param should be treated as lowercase", arg: "application/json; charset=UTF-8", want: "application/json; charset=utf-8"},
 		{name: "non charset param should not be changed", arg: "multipart/form-data; boundary=fooBar", want: "multipart/form-data; boundary=fooBar"},
 		{name: "no parameters should be normalized", arg: "APPLICATION/json;  ", want: "application/json"},

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -29,6 +29,7 @@ func TestCanonicalizeContentType(t *testing.T) {
 	}{
 		{name: "charset param should be treated as lowercase", arg: "application/json; charset=UTF-8", want: "application/json; charset=utf-8"},
 		{name: "non charset param should not be changed", arg: "multipart/form-data; boundary=fooBar", want: "multipart/form-data; boundary=fooBar"},
+		{name: "no parameters should not have base normalized", arg: "APPLICATION/json;  ", want: "application/json"},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -37,4 +38,27 @@ func TestCanonicalizeContentType(t *testing.T) {
 			assert.Equal(t, canonicalizeContentType(tt.arg), tt.want)
 		})
 	}
+}
+
+func BenchmarkCanonicalizeContentType(b *testing.B) {
+	b.Run("simple", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = canonicalizeContentType("application/json")
+		}
+		b.ReportAllocs()
+	})
+
+	b.Run("with charset", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = canonicalizeContentType("application/json; charset=utf-8")
+		}
+		b.ReportAllocs()
+	})
+
+	b.Run("with other param", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = canonicalizeContentType("application/json; foo=utf-8")
+		}
+		b.ReportAllocs()
+	})
 }

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -29,7 +29,7 @@ func TestCanonicalizeContentType(t *testing.T) {
 	}{
 		{name: "charset param should be treated as lowercase", arg: "application/json; charset=UTF-8", want: "application/json; charset=utf-8"},
 		{name: "non charset param should not be changed", arg: "multipart/form-data; boundary=fooBar", want: "multipart/form-data; boundary=fooBar"},
-		{name: "no parameters should not have base normalized", arg: "APPLICATION/json;  ", want: "application/json"},
+		{name: "no parameters should be normalized", arg: "APPLICATION/json;  ", want: "application/json"},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
For context, this function is run on every request within ServeHTTP, and the mime parsing and now lowercasing, is a marginal, but non trivial amount of memory allocations.

The expensive bit is hitting the mime.FormatMediaType path, when we already have a canonical form.

This removes the most expensive part over arguable the most common cases where there are no additional parameters on the Content-Type.

```
$ go test -bench '^BenchmarkCanonicalizeContentType$' -run '^$' .
goos: darwin
goarch: arm64
pkg: github.com/bufbuild/connect-go
BenchmarkCanonicalizeContentType/simple-10         	92344741	        12.85 ns/op	       0 B/op	       0 allocs/op
BenchmarkCanonicalizeContentType/with_charset-10   	 1744219	       693.8 ns/op	     424 B/op	       6 allocs/op
BenchmarkCanonicalizeContentType/with_other_param-10         	 1969113	       614.4 ns/op	     424 B/op	       6 allocs/op
PASS
ok  	github.com/bufbuild/connect-go	5.800s
```

**Before submitting your PR:** Please read through the contribution guide at https://github.com/bufbuild/connect-go/blob/main/.github/CONTRIBUTING.md
