### PR TITLE
Minimize allocations writing User-Agent header

### DIFF
--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -52,7 +52,7 @@ const (
 // defaultConnectUserAgent returns a User-Agent string similar to those used in gRPC.
 //
 //nolint:gochecknoglobals
-var defaultConnectUserAgent = []string{fmt.Sprintf("connect-go/%s (%s)", Version, runtime.Version())}
+var defaultConnectUserAgent = fmt.Sprintf("connect-go/%s (%s)", Version, runtime.Version())
 
 type protocolConnect struct{}
 
@@ -248,7 +248,7 @@ func (c *connectClient) WriteRequestHeader(streamType StreamType, header http.He
 	// We know these header keys are in canonical form, so we can bypass all the
 	// checks in Header.Set.
 	if header.Get(headerUserAgent) == "" {
-		header[headerUserAgent] = defaultConnectUserAgent
+		header[headerUserAgent] = []string{defaultConnectUserAgent}
 	}
 	header[connectHeaderProtocolVersion] = []string{connectProtocolVersion}
 	header[headerContentType] = []string{

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -49,6 +49,11 @@ const (
 	connectStreamingContentTypePrefix = "application/connect+"
 )
 
+// defaultConnectUserAgent returns a User-Agent string similar to those used in gRPC.
+//
+//nolint:gochecknoglobals
+var defaultConnectUserAgent = []string{fmt.Sprintf("connect-go/%s (%s)", Version, runtime.Version())}
+
 type protocolConnect struct{}
 
 // NewHandler implements protocol, so it must return an interface.
@@ -243,7 +248,7 @@ func (c *connectClient) WriteRequestHeader(streamType StreamType, header http.He
 	// We know these header keys are in canonical form, so we can bypass all the
 	// checks in Header.Set.
 	if header.Get(headerUserAgent) == "" {
-		header[headerUserAgent] = []string{connectUserAgent()}
+		header[headerUserAgent] = defaultConnectUserAgent
 	}
 	header[connectHeaderProtocolVersion] = []string{connectProtocolVersion}
 	header[headerContentType] = []string{
@@ -1026,11 +1031,6 @@ func connectHTTPToCode(httpCode int) Code {
 	default:
 		return CodeUnknown
 	}
-}
-
-// connectUserAgent returns a User-Agent string similar to those used in gRPC.
-func connectUserAgent() string {
-	return fmt.Sprintf("connect-go/%s (%s)", Version, runtime.Version())
 }
 
 func connectCodecFromContentType(streamType StreamType, contentType string) string {

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -65,6 +65,17 @@ var (
 	}
 	grpcTimeoutUnitLookup        = make(map[byte]time.Duration)
 	errTrailersWithoutGRPCStatus = fmt.Errorf("gRPC protocol error: no %s trailer", grpcHeaderStatus)
+
+	// defaultGrpcUserAgent follows
+	// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#user-agents:
+	//
+	//	While the protocol does not require a user-agent to function it is recommended
+	//	that clients provide a structured user-agent string that provides a basic
+	//	description of the calling library, version & platform to facilitate issue diagnosis
+	//	in heterogeneous environments. The following structure is recommended to library developers:
+	//
+	//	User-Agent → "grpc-" Language ?("-" Variant) "/" Version ?( " ("  *(AdditionalProperty ";") ")" )
+	defaultGrpcUserAgent = []string{fmt.Sprintf("grpc-go-connect/%s (%s)", Version, runtime.Version())}
 )
 
 func init() {
@@ -227,7 +238,7 @@ func (g *grpcClient) WriteRequestHeader(_ StreamType, header http.Header) {
 	// We know these header keys are in canonical form, so we can bypass all the
 	// checks in Header.Set.
 	if header.Get(headerUserAgent) == "" {
-		header[headerUserAgent] = []string{grpcUserAgent()}
+		header[headerUserAgent] = defaultGrpcUserAgent
 	}
 	header[headerContentType] = []string{grpcContentTypeFromCodecName(g.web, g.Codec.Name())}
 	// gRPC handles compression on a per-message basis, so we don't want to
@@ -760,19 +771,6 @@ func grpcEncodeTimeout(timeout time.Duration) (string, error) {
 	// The max time.Duration is smaller than the maximum expressible gRPC
 	// timeout, so we can't reach this case.
 	return "", errNoTimeout
-}
-
-// grpcUserAgent follows
-// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#user-agents:
-//
-//	While the protocol does not require a user-agent to function it is recommended
-//	that clients provide a structured user-agent string that provides a basic
-//	description of the calling library, version & platform to facilitate issue diagnosis
-//	in heterogeneous environments. The following structure is recommended to library developers:
-//
-//	User-Agent → "grpc-" Language ?("-" Variant) "/" Version ?( " ("  *(AdditionalProperty ";") ")" )
-func grpcUserAgent() string {
-	return fmt.Sprintf("grpc-go-connect/%s (%s)", Version, runtime.Version())
 }
 
 func grpcCodecFromContentType(web bool, contentType string) string {

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -75,7 +75,7 @@ var (
 	//	in heterogeneous environments. The following structure is recommended to library developers:
 	//
 	//	User-Agent → "grpc-" Language ?("-" Variant) "/" Version ?( " ("  *(AdditionalProperty ";") ")" )
-	defaultGrpcUserAgent = []string{fmt.Sprintf("grpc-go-connect/%s (%s)", Version, runtime.Version())}
+	defaultGrpcUserAgent = fmt.Sprintf("grpc-go-connect/%s (%s)", Version, runtime.Version())
 )
 
 func init() {
@@ -238,7 +238,7 @@ func (g *grpcClient) WriteRequestHeader(_ StreamType, header http.Header) {
 	// We know these header keys are in canonical form, so we can bypass all the
 	// checks in Header.Set.
 	if header.Get(headerUserAgent) == "" {
-		header[headerUserAgent] = defaultGrpcUserAgent
+		header[headerUserAgent] = []string{defaultGrpcUserAgent}
 	}
 	header[headerContentType] = []string{grpcContentTypeFromCodecName(g.web, g.Codec.Name())}
 	// gRPC handles compression on a per-message basis, so we don't want to


### PR DESCRIPTION
The fmt.Sprintf stood out again in my profiling as a relatively hot path, and through the lifetime of an application, this value will not change. So we can generate this header value at init() time and avoid the extra memory allocation as well on each request.

**Before submitting your PR:** Please read through the contribution guide at https://github.com/bufbuild/connect-go/blob/main/.github/CONTRIBUTING.md
