### PR TITLE
Optimize Peer lookups

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -291,12 +291,11 @@ type Peer struct {
 	Protocol string
 }
 
-func newPeerFromURL(urlString, protocol string) Peer {
-	peer := Peer{Protocol: protocol}
-	if u, err := url.Parse(urlString); err == nil {
-		peer.Addr = u.Host
+func newPeerFromURL(url *url.URL, protocol string) Peer {
+	return Peer{
+		Addr:     url.Host,
+		Protocol: protocol,
 	}
-	return peer
 }
 
 // handlerConnCloser extends HandlerConn with a method for handlers to

--- a/protocol.go
+++ b/protocol.go
@@ -237,20 +237,20 @@ func discard(reader io.Reader) error {
 	return err
 }
 
-func validateRequestURL(uri string) *Error {
-	_, err := url.ParseRequestURI(uri)
+func validateRequestURL(rawURL string) (*url.URL, *Error) {
+	url, err := url.ParseRequestURI(rawURL)
 	if err == nil {
-		return nil
+		return url, nil
 	}
-	if !strings.Contains(uri, "://") {
+	if !strings.Contains(rawURL, "://") {
 		// URL doesn't have a scheme, so the user is likely accustomed to
 		// grpc-go's APIs.
 		err = fmt.Errorf(
 			"URL %q missing scheme: use http:// or https:// (unlike grpc-go)",
-			uri,
+			rawURL,
 		)
 	}
-	return NewError(CodeUnavailable, err)
+	return nil, NewError(CodeUnavailable, err)
 }
 
 // negotiateCompression determines and validates the request compression and

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -69,10 +69,14 @@ func (*protocolConnect) NewHandler(params *protocolHandlerParams) protocolHandle
 
 // NewClient implements protocol, so it must return an interface.
 func (*protocolConnect) NewClient(params *protocolClientParams) (protocolClient, error) {
-	if err := validateRequestURL(params.URL); err != nil {
+	url, err := validateRequestURL(params.URL)
+	if err != nil {
 		return nil, err
 	}
-	return &connectClient{protocolClientParams: *params}, nil
+	return &connectClient{
+		protocolClientParams: *params,
+		peer:                 newPeerFromURL(url, ProtocolConnect),
+	}, nil
 }
 
 type connectHandler struct {
@@ -233,10 +237,12 @@ func (h *connectHandler) NewConn(
 
 type connectClient struct {
 	protocolClientParams
+
+	peer Peer
 }
 
 func (c *connectClient) Peer() Peer {
-	return newPeerFromURL(c.URL, ProtocolConnect)
+	return c.peer
 }
 
 func (c *connectClient) WriteRequestHeader(streamType StreamType, header http.Header) {

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -23,7 +23,6 @@ import (
 	"math"
 	"net/http"
 	"net/textproto"
-	"net/url"
 	"runtime"
 	"strconv"
 	"strings"
@@ -104,10 +103,14 @@ func (g *protocolGRPC) NewClient(params *protocolClientParams) (protocolClient, 
 	if err != nil {
 		return nil, err
 	}
+	peer := newPeerFromURL(url, ProtocolGRPC)
+	if g.web {
+		peer = newPeerFromURL(url, ProtocolGRPCWeb)
+	}
 	return &grpcClient{
 		protocolClientParams: *params,
 		web:                  g.web,
-		peer:                 newGrpcPeerFromURL(url, g.web),
+		peer:                 peer,
 	}, nil
 }
 
@@ -218,13 +221,6 @@ type grpcClient struct {
 
 	web  bool
 	peer Peer
-}
-
-func newGrpcPeerFromURL(url *url.URL, web bool) Peer {
-	if web {
-		return newPeerFromURL(url, ProtocolGRPCWeb)
-	}
-	return newPeerFromURL(url, ProtocolGRPC)
 }
 
 func (g *grpcClient) Peer() Peer {


### PR DESCRIPTION
I don't know if there was an intention behind lazily initializing the Peer struct on-demand within the Peer() method, but from what I can tell, Peer() ends up being called 100% of the time in every path I've seen, and within NewClient, it's ultimately called twice.

Within NewClient, we also parse the params.URL then multiple times through url.ParseRequestURI then again through url.Parse, which is rather expensive and requires at least 1 heap allocation for the url.URL struct which we discard.

This behavior changes so the URL itself is parsed 1 time, then pass the url.URL struct to both functions that need it. As well as memoize the actual Peer on our concrete Client struct.

There is a slight change in behavior, but from my understanding, this seems safe:

validateRequestURL runs through url.ParseRequestURI, and newPeerFromURL was passed through url.Parse instead. From my understanding and my testing, url.ParseRequestURI is more strict than url.Parse, but since validateRequestURL was always called first, I don't particularly see how a less strict URL could have gotten through to the subsequent call to create the Peer.

**Before submitting your PR:** Please read through the contribution guide at https://github.com/bufbuild/connect-go/blob/main/.github/CONTRIBUTING.md
