### PR TITLE
Use lowercase for all header keys

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -35,9 +35,9 @@ const (
 )
 
 const (
-	headerContentType = "Content-Type"
-	headerUserAgent   = "User-Agent"
-	headerTrailer     = "Trailer"
+	headerContentType = "content-type"
+	headerUserAgent   = "user-agent"
+	headerTrailer     = "trailer"
 
 	discardLimit = 1024 * 1024 * 4 // 4MiB
 )

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -33,13 +33,13 @@ import (
 )
 
 const (
-	connectUnaryHeaderCompression           = "Content-Encoding"
-	connectUnaryHeaderAcceptCompression     = "Accept-Encoding"
-	connectUnaryTrailerPrefix               = "Trailer-"
-	connectStreamingHeaderCompression       = "Connect-Content-Encoding"
-	connectStreamingHeaderAcceptCompression = "Connect-Accept-Encoding"
-	connectHeaderTimeout                    = "Connect-Timeout-Ms"
-	connectHeaderProtocolVersion            = "Connect-Protocol-Version"
+	connectUnaryHeaderCompression           = "content-encoding"
+	connectUnaryHeaderAcceptCompression     = "accept-encoding"
+	connectUnaryTrailerPrefix               = "trailer-"
+	connectStreamingHeaderCompression       = "connect-content-encoding"
+	connectStreamingHeaderAcceptCompression = "connect-accept-encoding"
+	connectHeaderTimeout                    = "connect-timeout-ms"
+	connectHeaderProtocolVersion            = "connect-protocol-version"
 	connectProtocolVersion                  = "1"
 
 	connectFlagEnvelopeEndStream = 0b00000010

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -33,12 +33,12 @@ import (
 )
 
 const (
-	grpcHeaderCompression       = "Grpc-Encoding"
-	grpcHeaderAcceptCompression = "Grpc-Accept-Encoding"
-	grpcHeaderTimeout           = "Grpc-Timeout"
-	grpcHeaderStatus            = "Grpc-Status"
-	grpcHeaderMessage           = "Grpc-Message"
-	grpcHeaderDetails           = "Grpc-Status-Details-Bin"
+	grpcHeaderCompression       = "grpc-encoding"
+	grpcHeaderAcceptCompression = "grpc-accept-encoding"
+	grpcHeaderTimeout           = "grpc-timeout"
+	grpcHeaderStatus            = "grpc-status"
+	grpcHeaderMessage           = "grpc-message"
+	grpcHeaderDetails           = "grpc-status-details-bin"
 
 	grpcFlagEnvelopeTrailer = 0b10000000
 


### PR DESCRIPTION
See https://github.com/bufbuild/connect-go/issues/453.

This goes ahead and uses lowercase for all of our header keys, see the comment in `header.go` on this PR.

Note that this breaks a bunch of our tests, which is worrisome in itself - in theory, this should cause no issues with the tests, so I'm not sure if this is because of the tests, or because of some deeper concerns, but someone with more intimate familiarity with the codebase may know off the top of their heads.

Another option would be to special-case when `protocolGRPC.web == true`, and feed this the whole way down, but if the position we have is that we're case-insensitive on headers, then all lowercase should not matter, and we can more easily do it without special-casing. However, an argument for special-casing can be made: (1) if we do all lowercase and then clients come to rely on this, that's bad, and we can say that we only do this for grpc-web for legacy reasons (2) this may break existing poorly-behaving callers, but per the gRPC and Connect specs, it should not so I'm not sure if this is our responsibility.