### PR TITLE
More explicit error on empty JSON bodies

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -15,6 +15,7 @@
 package connect
 
 import (
+	"errors"
 	"fmt"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -92,6 +93,9 @@ func (c *protoJSONCodec) Unmarshal(binary []byte, message any) error {
 	protoMessage, ok := message.(proto.Message)
 	if !ok {
 		return errNotProto(message)
+	}
+	if len(binary) == 0 {
+		return errors.New("empty string is not a valid JSON object")
 	}
 	var options protojson.UnmarshalOptions
 	return options.Unmarshal(binary, protoMessage)

--- a/codec.go
+++ b/codec.go
@@ -95,7 +95,7 @@ func (c *protoJSONCodec) Unmarshal(binary []byte, message any) error {
 		return errNotProto(message)
 	}
 	if len(binary) == 0 {
-		return errors.New("empty string is not a valid JSON object")
+		return errors.New("zero-length payload is not a valid JSON object")
 	}
 	var options protojson.UnmarshalOptions
 	return options.Unmarshal(binary, protoMessage)

--- a/codec_test.go
+++ b/codec_test.go
@@ -29,9 +29,9 @@ func TestJSONCodec(t *testing.T) {
 	codec := &protoJSONCodec{name: "json"}
 	err := codec.Unmarshal([]byte{}, &empty)
 	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(
-		err.Error(),
-		"valid JSON",
+	assert.True(
+		t,
+		strings.Contains(err.Error(), "valid JSON"),
 		assert.Sprintf(`error message should explain that "" is not a valid JSON object`),
-	))
+	)
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,37 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bufbuild/connect-go/internal/assert"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestJSONCodec(t *testing.T) {
+	t.Parallel()
+
+	var empty emptypb.Empty
+	codec := &protoJSONCodec{name: "json"}
+	err := codec.Unmarshal([]byte{}, &empty)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(
+		err.Error(),
+		"valid JSON",
+		assert.Sprintf(`error message should explain that "" is not a valid JSON object`),
+	))
+}


### PR DESCRIPTION
Return a more understandable error when the JSON codec attempts to
unmarshal an empty body.

Fixes #452.
