### PR TITLE
Add stable codec interface and implementations

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -53,6 +53,8 @@ type Codec interface {
 
 // stableCodec is an extension to Codec for serializing with stable output.
 type stableCodec interface {
+	Codec
+
 	// MarshalStable marshals the given message with stable field ordering.
 	//
 	// MarshalStable should return the same output for a given input. Although

--- a/codec.go
+++ b/codec.go
@@ -15,6 +15,8 @@
 package connect
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -49,6 +51,30 @@ type Codec interface {
 	Unmarshal([]byte, any) error
 }
 
+// StableCodec is an extension to Codec for serializing with stable output.
+type StableCodec interface {
+	// MarshalStable marshals the given message with stable field ordering.
+	//
+	// MarshalStable should return the same output for a given input. Although
+	// it is not guaranteed to be canonicalized, the marshalling routine for
+	// MarshalStable will opt for the most normalized output available for a
+	// given serialization.
+	//
+	// For practical reasons, it is possible for MarshalStable to return two
+	// different results for two inputs considered to be "equal" in their own
+	// domain, and it may change in the future with codec updates, but for
+	// any given concrete value and any given version, it should return the
+	// same output.
+	MarshalStable(any) ([]byte, error)
+
+	// IsBinary returns true if the marshalled data is binary for this codec.
+	//
+	// If this function returns false, the data returned from Marshal and
+	// MarshalStable are considered valid text and may be used in contexts
+	// where text is expected.
+	IsBinary() bool
+}
+
 type protoBinaryCodec struct{}
 
 var _ Codec = (*protoBinaryCodec)(nil)
@@ -69,6 +95,23 @@ func (c *protoBinaryCodec) Unmarshal(data []byte, message any) error {
 		return errNotProto(message)
 	}
 	return proto.Unmarshal(data, protoMessage)
+}
+
+func (c *protoBinaryCodec) MarshalStable(message any) ([]byte, error) {
+	protoMessage, ok := message.(proto.Message)
+	if !ok {
+		return nil, errNotProto(message)
+	}
+	// protobuf does not offer a canonical output today, so this format is not
+	// guaranteed to match deterministic output from other protobuf libraries.
+	// In addition, unknown fields may cause inconsistent output for otherwise
+	// equal messages.
+	options := proto.MarshalOptions{Deterministic: true}
+	return options.Marshal(protoMessage)
+}
+
+func (c *protoBinaryCodec) IsBinary() bool {
+	return true
 }
 
 type protoJSONCodec struct {
@@ -95,6 +138,26 @@ func (c *protoJSONCodec) Unmarshal(binary []byte, message any) error {
 	}
 	var options protojson.UnmarshalOptions
 	return options.Unmarshal(binary, protoMessage)
+}
+
+func (c *protoJSONCodec) MarshalStable(message any) ([]byte, error) {
+	// protojson does not offer a "deterministic" field ordering, but fields
+	// are still ordered consistently by their index. However, protojson can
+	// output inconsistent whitespace for some reason, therefore it is
+	// suggested to use a formatter to ensure consistent formatting.
+	compactedJSON := new(bytes.Buffer)
+	messageJSON, err := c.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	if err = json.Compact(compactedJSON, messageJSON); err != nil {
+		return nil, err
+	}
+	return compactedJSON.Bytes(), nil
+}
+
+func (c *protoJSONCodec) IsBinary() bool {
+	return false
 }
 
 // readOnlyCodecs is a read-only interface to a map of named codecs.

--- a/codec.go
+++ b/codec.go
@@ -106,6 +106,7 @@ func (c *protoBinaryCodec) MarshalStable(message any) ([]byte, error) {
 	// guaranteed to match deterministic output from other protobuf libraries.
 	// In addition, unknown fields may cause inconsistent output for otherwise
 	// equal messages.
+	// https://github.com/golang/protobuf/issues/1121
 	options := proto.MarshalOptions{Deterministic: true}
 	return options.Marshal(protoMessage)
 }
@@ -145,6 +146,7 @@ func (c *protoJSONCodec) MarshalStable(message any) ([]byte, error) {
 	// are still ordered consistently by their index. However, protojson can
 	// output inconsistent whitespace for some reason, therefore it is
 	// suggested to use a formatter to ensure consistent formatting.
+	// https://github.com/golang/protobuf/issues/1373
 	compactedJSON := new(bytes.Buffer)
 	messageJSON, err := c.Marshal(message)
 	if err != nil {

--- a/codec.go
+++ b/codec.go
@@ -51,8 +51,8 @@ type Codec interface {
 	Unmarshal([]byte, any) error
 }
 
-// StableCodec is an extension to Codec for serializing with stable output.
-type StableCodec interface {
+// stableCodec is an extension to Codec for serializing with stable output.
+type stableCodec interface {
 	// MarshalStable marshals the given message with stable field ordering.
 	//
 	// MarshalStable should return the same output for a given input. Although

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,62 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect
+
+import (
+	"testing"
+
+	"github.com/bufbuild/connect-go/internal/assert"
+	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
+)
+
+func TestCodec(t *testing.T) {
+	t.Parallel()
+	assertCodecRoundTrips(t, &protoBinaryCodec{})
+	assertCodecRoundTrips(t, &protoJSONCodec{})
+	assertStableMarshalEquals(
+		t,
+		&protoBinaryCodec{},
+		&pingv1.PingRequest{Text: "text", Number: 1}, []byte{
+			// Comments are in the format of protoscope.
+			// 1:VARINT 1
+			0b00001_000, 1,
+			// 2:LEN 4 "test"
+			0b00010_010, 4, 0x74, 0x65, 0x78, 0x74,
+		},
+	)
+	assertStableMarshalEquals(
+		t,
+		&protoJSONCodec{},
+		&pingv1.PingRequest{Text: "text", Number: 1},
+		[]byte(`{"number":"1","text":"text"}`),
+	)
+}
+
+func assertCodecRoundTrips(tb testing.TB, codec Codec) {
+	tb.Helper()
+	got := pingv1.PingRequest{}
+	want := pingv1.PingRequest{Text: "text", Number: 1}
+	data, err := codec.Marshal(&want)
+	assert.Nil(tb, err)
+	assert.Nil(tb, codec.Unmarshal(data, &got))
+	assert.Equal(tb, &got, &want)
+}
+
+func assertStableMarshalEquals(tb testing.TB, codec stableCodec, message any, want []byte) {
+	tb.Helper()
+	got, err := codec.MarshalStable(message)
+	assert.Nil(tb, err)
+	assert.Equal(tb, got, want)
+}


### PR DESCRIPTION
Unfortunately, protobuf offers no story whatsoever for canonicalization of protobuf or protojson output. It seems the best we can get is to just make it deterministic within each implementation.

Question: I did not add tests for this particular code because codecs are currently not tested on their own. Should we start having unit tests for the codecs now?

Related issues:
* https://github.com/golang/protobuf/issues/1121
* https://github.com/golang/protobuf/issues/1373