### PR TITLE
Use lowercase keys for gRPC-web trailers appended to the response body

### DIFF
--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -582,7 +582,12 @@ type grpcMarshaler struct {
 func (m *grpcMarshaler) MarshalWebTrailers(trailer http.Header) *Error {
 	raw := m.envelopeWriter.bufferPool.Get()
 	defer m.envelopeWriter.bufferPool.Put(raw)
-	if err := trailer.Write(raw); err != nil {
+	lcTrailer := http.Header{}
+	for key, element := range trailer {
+		lcKey := strings.ToLower(key)
+		lcTrailer[lcKey] = element
+	}
+	if err := lcTrailer.Write(raw); err != nil {
 		return errorf(CodeInternal, "format trailers: %w", err)
 	}
 	return m.Write(&envelope{

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -583,8 +583,15 @@ func (m *grpcMarshaler) MarshalWebTrailers(trailer http.Header) *Error {
 	raw := m.envelopeWriter.bufferPool.Get()
 	defer m.envelopeWriter.bufferPool.Put(raw)
 	for key, values := range trailer {
+		// Per the Go specification, keys inserted during iteration may be produced
+		// later in the iteration or may be skipped. For safety, avoid mutating the
+		// map if the key is already lower-cased.
+		lower := strings.ToLower(key)
+		if key == lower {
+			continue
+		}
 		delete(trailer, key)
-		trailer[strings.ToLower(key)] = values
+		trailer[lower] = values
 	}
 	if err := trailer.Write(raw); err != nil {
 		return errorf(CodeInternal, "format trailers: %w", err)

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -582,12 +582,11 @@ type grpcMarshaler struct {
 func (m *grpcMarshaler) MarshalWebTrailers(trailer http.Header) *Error {
 	raw := m.envelopeWriter.bufferPool.Get()
 	defer m.envelopeWriter.bufferPool.Put(raw)
-	lcTrailer := http.Header{}
-	for key, element := range trailer {
-		lcKey := strings.ToLower(key)
-		lcTrailer[lcKey] = element
+	for key, values := range trailer {
+		delete(trailer, key)
+		trailer[strings.ToLower(key)] = values
 	}
-	if err := lcTrailer.Write(raw); err != nil {
+	if err := trailer.Write(raw); err != nil {
 		return errorf(CodeInternal, "format trailers: %w", err)
 	}
 	return m.Write(&envelope{


### PR DESCRIPTION
As a partial solution to #453, lower-case keys when appending gRPC-Web trailers to the response body. This is uncontroversial, since it only affects a portion of the wire format specific to gRPC-Web.

This does _not_ address trailers-only responses or standard response headers, which the gRPC-Web specification seems to also demand in lowercase.