### PR TITLE
Improve errors for outdated protobuf runtimes

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -20,6 +20,7 @@ import (
 
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/runtime/protoiface"
 )
 
 const (
@@ -147,5 +148,8 @@ func (m *codecMap) Names() []string {
 }
 
 func errNotProto(message any) error {
+	if _, ok := message.(protoiface.MessageV1); ok {
+		return fmt.Errorf("%T uses github.com/golang/protobuf, but connect-go only supports google.golang.org/protobuf: see https://go.dev/blog/protobuf-apiv2", message)
+	}
 	return fmt.Errorf("%T doesn't implement proto.Message", message)
 }


### PR DESCRIPTION
When users try to use Connect with types generated by v1 of the protobuf
runtime (github.com/golang/protobuf), they get a generic message
complaining that their type doesn't implement `proto.Message`. This is
confusing, because the message does implement a `proto.Message`
interface - just from a different `proto` package. This PR adds a bit of
logic to the protobuf codecs to provide better errors in this case.

This error message is intentionally long: it uses
"github.com/golang/protobuf" and "google.golang.org/protobuf" rather
than "v1" and "v2" to avoid confusion with proto2 and proto3, and it
includes a link to a Go blog post that explains the migration in detail.

@cyriltovena ran into this, as did a few other other users I've spoken to.
Let's save them some debugging time :)
