### PR TITLE
Parse the url only once per Client

### DIFF
--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -62,6 +62,13 @@ func newDuplexHTTPCall(
 	// to mutate the req.URL, we don't feel the effects of it.
 	url = cloneURL(url)
 	pipeReader, pipeWriter := io.Pipe()
+
+	// This is mirroring what http.NewRequestContext did, but
+	// using an already parsed url.URL object, rather than a string
+	// and parsing it again. This is a bit funny with HTTP/1.1
+	// explicitly, but this is logic copied over from
+	// NewRequestContext and doesn't effect the actual version
+	// being transmitted.
 	request := (&http.Request{
 		Method:     http.MethodPost,
 		URL:        url,

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -284,15 +284,15 @@ func (d *duplexHTTPCall) getError() error {
 }
 
 // See: https://cs.opensource.google/go/go/+/refs/tags/go1.20.1:src/net/http/clone.go;l=22-33
-func cloneURL(u *url.URL) *url.URL {
-	if u == nil {
+func cloneURL(oldURL *url.URL) *url.URL {
+	if oldURL == nil {
 		return nil
 	}
-	u2 := new(url.URL)
-	*u2 = *u
-	if u.User != nil {
-		u2.User = new(url.Userinfo)
-		*u2.User = *u.User
+	newURL := new(url.URL)
+	*newURL = *oldURL
+	if oldURL.User != nil {
+		newURL.User = new(url.Userinfo)
+		*newURL.User = *oldURL.User
 	}
-	return u2
+	return newURL
 }

--- a/protobuf_util.go
+++ b/protobuf_util.go
@@ -22,8 +22,8 @@ import (
 // corresponding to the Protobuf package, service, and method. It always starts
 // with a slash. Within connect, we use this as (1) Spec.Procedure and (2) the
 // path when mounting handlers on muxes.
-func extractProtoPath(url string) string {
-	segments := strings.Split(url, "/")
+func extractProtoPath(path string) string {
+	segments := strings.Split(path, "/")
 	var pkg, method string
 	if len(segments) > 0 {
 		pkg = segments[0]

--- a/protocol.go
+++ b/protocol.go
@@ -109,7 +109,7 @@ type protocolClientParams struct {
 	Codec            Codec
 	CompressMinBytes int
 	HTTPClient       HTTPClient
-	URL              string
+	URL              *url.URL
 	BufferPool       *bufferPool
 	ReadMaxBytes     int
 	SendMaxBytes     int
@@ -236,22 +236,6 @@ func discard(reader io.Reader) error {
 	lr := &io.LimitedReader{R: reader, N: discardLimit}
 	_, err := io.Copy(io.Discard, lr)
 	return err
-}
-
-func validateRequestURL(rawURL string) (*url.URL, *Error) {
-	url, err := url.ParseRequestURI(rawURL)
-	if err == nil {
-		return url, nil
-	}
-	if !strings.Contains(rawURL, "://") {
-		// URL doesn't have a scheme, so the user is likely accustomed to
-		// grpc-go's APIs.
-		err = fmt.Errorf(
-			"URL %q missing scheme: use http:// or https:// (unlike grpc-go)",
-			rawURL,
-		)
-	}
-	return nil, NewError(CodeUnavailable, err)
 }
 
 // negotiateCompression determines and validates the request compression and

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -74,13 +74,9 @@ func (*protocolConnect) NewHandler(params *protocolHandlerParams) protocolHandle
 
 // NewClient implements protocol, so it must return an interface.
 func (*protocolConnect) NewClient(params *protocolClientParams) (protocolClient, error) {
-	url, err := validateRequestURL(params.URL)
-	if err != nil {
-		return nil, err
-	}
 	return &connectClient{
 		protocolClientParams: *params,
-		peer:                 newPeerFromURL(url, ProtocolConnect),
+		peer:                 newPeerFromURL(params.URL, ProtocolConnect),
 	}, nil
 }
 

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -110,13 +110,9 @@ func (g *protocolGRPC) NewHandler(params *protocolHandlerParams) protocolHandler
 
 // NewClient implements protocol, so it must return an interface.
 func (g *protocolGRPC) NewClient(params *protocolClientParams) (protocolClient, error) {
-	url, err := validateRequestURL(params.URL)
-	if err != nil {
-		return nil, err
-	}
-	peer := newPeerFromURL(url, ProtocolGRPC)
+	peer := newPeerFromURL(params.URL, ProtocolGRPC)
 	if g.web {
-		peer = newPeerFromURL(url, ProtocolGRPCWeb)
+		peer = newPeerFromURL(params.URL, ProtocolGRPCWeb)
 	}
 	return &grpcClient{
 		protocolClientParams: *params,


### PR DESCRIPTION
This stood out on flame graphs due ultimately to the http.NewRequestFromContext call, which ends up calling url.Parse and this happens on every single RPC call.

I did an optimization in #447 which similarly, and this is a natural extension of this.

We can just parse the url string once during NewClient, validate at that point, then tag along the parsed *url.URL everywhere else and never use it as a string again. This value never mutates through the lifetime of a Client and isn't publicly available on any structs.

Before:
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/375744/219882639-b05416ee-3a8f-4b38-9716-9d66a34eeffc.png">

After:
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/375744/220477453-c1b48350-665b-495b-a070-3efb08e53067.png">
