### PR TITLE
Clarify purpose of handler_stream_test.go

### DIFF
--- a/handler_stream_test.go
+++ b/handler_stream_test.go
@@ -39,3 +39,18 @@ type nopClientStreamingHandlerConn struct {
 func (nopClientStreamingHandlerConn) Receive(msg any) error {
 	return nil
 }
+
+func TestServerStream(t *testing.T) {
+	t.Parallel()
+	serverStream := &ServerStream[pingv1.PingResponse]{conn: &nopServerStreamingHandlerConn{}}
+	assert.Nil(t, serverStream.Send(&pingv1.PingResponse{}))
+}
+
+type nopServerStreamingHandlerConn struct {
+	StreamingHandlerConn
+}
+
+func (nopServerStreamingHandlerConn) Send(msg any) error {
+	return nil
+}
+

--- a/handler_stream_test.go
+++ b/handler_stream_test.go
@@ -39,18 +39,3 @@ type nopClientStreamingHandlerConn struct {
 func (nopClientStreamingHandlerConn) Receive(msg any) error {
 	return nil
 }
-
-func TestServerStream(t *testing.T) {
-	t.Parallel()
-	serverStream := &ServerStream[pingv1.PingResponse]{conn: &nopServerStreamingHandlerConn{}}
-	assert.Nil(t, serverStream.Send(&pingv1.PingResponse{}))
-}
-
-type nopServerStreamingHandlerConn struct {
-	StreamingHandlerConn
-}
-
-func (nopServerStreamingHandlerConn) Send(msg any) error {
-	return nil
-}
-

--- a/handler_stream_test.go
+++ b/handler_stream_test.go
@@ -54,3 +54,23 @@ func (nopServerStreamingHandlerConn) Send(msg any) error {
 	return nil
 }
 
+func TestBidiStream(t *testing.T) {
+	t.Parallel()
+	bidiStream := &BidiStream[pingv1.PingRequest, pingv1.PingResponse]{conn: &nopBidiStreamingHandlerConn{}}
+	res, err := bidiStream.Receive()
+	assert.NotNil(t, res)
+	assert.Nil(t, err)
+	assert.Nil(t, bidiStream.Send(&pingv1.PingResponse{}))
+}
+
+type nopBidiStreamingHandlerConn struct {
+	StreamingHandlerConn
+}
+
+func (nopBidiStreamingHandlerConn) Receive(msg any) error {
+	return nil
+}
+
+func (nopBidiStreamingHandlerConn) Send(msg any) error {
+	return nil
+}

--- a/handler_stream_test.go
+++ b/handler_stream_test.go
@@ -22,14 +22,17 @@ import (
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 )
 
-func TestClientStream(t *testing.T) {
+func TestClientStreamIterator(t *testing.T) {
 	t.Parallel()
+	// The server's view of a client streaming RPC is an iterator. For safety,
+	// and to match grpc-go's behavior, we should allocate a new message for each
+	// iteration.
 	stream := &ClientStream[pingv1.PingRequest]{conn: &nopStreamingHandlerConn{}}
 	assert.True(t, stream.Receive())
 	first := fmt.Sprintf("%p", stream.Msg())
 	assert.True(t, stream.Receive())
 	second := fmt.Sprintf("%p", stream.Msg())
-	assert.NotEqual(t, first, second)
+	assert.NotEqual(t, first, second, assert.Sprintf("should allocate a new message for each iteration"))
 }
 
 type nopStreamingHandlerConn struct {

--- a/handler_stream_test.go
+++ b/handler_stream_test.go
@@ -24,18 +24,18 @@ import (
 
 func TestClientStream(t *testing.T) {
 	t.Parallel()
-	stream := &ClientStream[pingv1.PingRequest]{conn: &nopStreamingHandlerConn{}}
-	assert.True(t, stream.Receive())
-	first := fmt.Sprintf("%p", stream.Msg())
-	assert.True(t, stream.Receive())
-	second := fmt.Sprintf("%p", stream.Msg())
+	clientStream := &ClientStream[pingv1.PingRequest]{conn: &nopClientStreamingHandlerConn{}}
+	assert.True(t, clientStream.Receive())
+	first := fmt.Sprintf("%p", clientStream.Msg())
+	assert.True(t, clientStream.Receive())
+	second := fmt.Sprintf("%p", clientStream.Msg())
 	assert.NotEqual(t, first, second)
 }
 
-type nopStreamingHandlerConn struct {
+type nopClientStreamingHandlerConn struct {
 	StreamingHandlerConn
 }
 
-func (nopStreamingHandlerConn) Receive(msg any) error {
+func (nopClientStreamingHandlerConn) Receive(msg any) error {
 	return nil
 }

--- a/handler_stream_test.go
+++ b/handler_stream_test.go
@@ -24,18 +24,18 @@ import (
 
 func TestClientStream(t *testing.T) {
 	t.Parallel()
-	clientStream := &ClientStream[pingv1.PingRequest]{conn: &nopClientStreamingHandlerConn{}}
-	assert.True(t, clientStream.Receive())
-	first := fmt.Sprintf("%p", clientStream.Msg())
-	assert.True(t, clientStream.Receive())
-	second := fmt.Sprintf("%p", clientStream.Msg())
+	stream := &ClientStream[pingv1.PingRequest]{conn: &nopStreamingHandlerConn{}}
+	assert.True(t, stream.Receive())
+	first := fmt.Sprintf("%p", stream.Msg())
+	assert.True(t, stream.Receive())
+	second := fmt.Sprintf("%p", stream.Msg())
 	assert.NotEqual(t, first, second)
 }
 
-type nopClientStreamingHandlerConn struct {
+type nopStreamingHandlerConn struct {
 	StreamingHandlerConn
 }
 
-func (nopClientStreamingHandlerConn) Receive(msg any) error {
+func (nopStreamingHandlerConn) Receive(msg any) error {
 	return nil
 }

--- a/handler_stream_test.go
+++ b/handler_stream_test.go
@@ -54,23 +54,3 @@ func (nopServerStreamingHandlerConn) Send(msg any) error {
 	return nil
 }
 
-func TestBidiStream(t *testing.T) {
-	t.Parallel()
-	bidiStream := &BidiStream[pingv1.PingRequest, pingv1.PingResponse]{conn: &nopBidiStreamingHandlerConn{}}
-	res, err := bidiStream.Receive()
-	assert.NotNil(t, res)
-	assert.Nil(t, err)
-	assert.Nil(t, bidiStream.Send(&pingv1.PingResponse{}))
-}
-
-type nopBidiStreamingHandlerConn struct {
-	StreamingHandlerConn
-}
-
-func (nopBidiStreamingHandlerConn) Receive(msg any) error {
-	return nil
-}
-
-func (nopBidiStreamingHandlerConn) Send(msg any) error {
-	return nil
-}


### PR DESCRIPTION
Clarify that the sole purpose of the test in `handler_stream_test.go` is to verify a safety property of the `ClientStream` iterator. A similar testing strategy isn't worthwhile for `ServerStream` or `BidiStream`, because they're not iterators.