### PR TITLE
Client.CallServerStream should populate spec and peer of Request

### DIFF
--- a/client.go
+++ b/client.go
@@ -135,6 +135,8 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 		return nil, c.err
 	}
 	conn := c.newConn(ctx, StreamTypeServer)
+	request.spec = conn.Spec()
+	request.peer = conn.Peer()
 	mergeHeaders(conn.RequestHeader(), request.header)
 	// Send always returns an io.EOF unless the error is from the client-side.
 	// We want the user to continue to call Receive in those cases to get the


### PR DESCRIPTION
Neither `ServerStream` nor `ServerStreamForClient` include `Spec()` and `Peer()` methods. This is presumably because the signatures for handlers and stubs includes a `Request`, which _does_ have these methods.

However, on the client side, when invoking a server stream, these fields were never populated on the `Request`. They are technically still accessible via `stream.Conn()`. But since `ClientStream` and `BidiStream` have methods for these, without making the caller poke into the underlying conn, it seemed like this was likely not the expected way to retrieve these attributes.

So this PR simply updates the client-side stub so that calling a server-stream method _does_ populate the relevant fields of the `Request`. This provides convenient and consistent access to these fields for client code.