### PR TITLE
Prepare for v1.6.0

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.6.0-dev"
+const Version = "1.6.0"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
We have quite a few improvements piled up on `main` - let's cut a new release
next week and clear the decks for GET support.
