### PR TITLE
Prepare for v1.7.0

### DIFF
--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -175,7 +175,7 @@ func generatePreamble(g *protogen.GeneratedFile, file *protogen.File) {
 		"compiled into your binary. You can fix the problem by either regenerating this code ",
 		"with an older version of connect or updating the connect version compiled into your binary.")
 	if needsWithIdempotency(file) {
-		g.P("const _ = ", connectPackage.Ident("IsAtLeastVersion1_6_0"))
+		g.P("const _ = ", connectPackage.Ident("IsAtLeastVersion1_7_0"))
 	} else {
 		g.P("const _ = ", connectPackage.Ident("IsAtLeastVersion0_1_0"))
 	}

--- a/connect.go
+++ b/connect.go
@@ -32,14 +32,14 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.7.0-dev"
+const Version = "1.7.0"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.
 const (
 	IsAtLeastVersion0_0_1 = true
 	IsAtLeastVersion0_1_0 = true
-	IsAtLeastVersion1_6_0 = true
+	IsAtLeastVersion1_7_0 = true
 )
 
 // StreamType describes whether the client, server, neither, or both is

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -37,7 +37,7 @@ import (
 // generated with a version of connect newer than the one compiled into your binary. You can fix the
 // problem by either regenerating this code with an older version of connect or updating the connect
 // version compiled into your binary.
-const _ = connect_go.IsAtLeastVersion1_6_0
+const _ = connect_go.IsAtLeastVersion1_7_0
 
 const (
 	// PingServiceName is the fully-qualified name of the PingService service.


### PR DESCRIPTION
Prepares for the Connect v1.7.0 release, featuring Connect Get support.

Changes the `IsAtLeastVersion1_6_0` constant to `IsAtLeastVersion1_7_0` too, since it actually is from changes that only landed afterwards.
