### PR TITLE
Prefix comments with correct identifier name

### DIFF
--- a/error.go
+++ b/error.go
@@ -295,7 +295,7 @@ func wrapIfContextError(err error) error {
 	return err
 }
 
-// wrapIfLikelyWithGRPCNotUsedError adds a wrapping error that has a message
+// wrapIfLikelyH2CNotConfiguredError adds a wrapping error that has a message
 // telling the caller that they likely need to use h2c but are using a raw http.Client{}.
 //
 // This happens when running a gRPC-only server.

--- a/header.go
+++ b/header.go
@@ -51,7 +51,7 @@ func mergeHeaders(into, from http.Header) {
 	}
 }
 
-// getCanonicalHeader is a shortcut for Header.Get() which
+// getHeaderCanonical is a shortcut for Header.Get() which
 // bypasses the CanonicalMIMEHeaderKey operation when we
 // know the key is already in canonical form.
 func getHeaderCanonical(h http.Header, key string) string {


### PR DESCRIPTION
To match typical Go style (even for unexported identifiers), the first word of most documentation comments should be the identifier name.