### PR TITLE
[#477] add WithProtoJSONOptions() expose protojson marshalling options

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -120,7 +120,9 @@ func (c *protoBinaryCodec) IsBinary() bool {
 }
 
 type protoJSONCodec struct {
-	name string
+	name             string
+	marshalOptions   protojson.MarshalOptions
+	unmarshalOptions protojson.UnmarshalOptions
 }
 
 var _ Codec = (*protoJSONCodec)(nil)
@@ -132,8 +134,7 @@ func (c *protoJSONCodec) Marshal(message any) ([]byte, error) {
 	if !ok {
 		return nil, errNotProto(message)
 	}
-	var options protojson.MarshalOptions
-	return options.Marshal(protoMessage)
+	return c.marshalOptions.Marshal(protoMessage)
 }
 
 func (c *protoJSONCodec) Unmarshal(binary []byte, message any) error {
@@ -144,8 +145,7 @@ func (c *protoJSONCodec) Unmarshal(binary []byte, message any) error {
 	if len(binary) == 0 {
 		return errors.New("zero-length payload is not a valid JSON object")
 	}
-	var options protojson.UnmarshalOptions
-	return options.Unmarshal(binary, protoMessage)
+	return c.unmarshalOptions.Unmarshal(binary, protoMessage)
 }
 
 func (c *protoJSONCodec) MarshalStable(message any) ([]byte, error) {

--- a/option.go
+++ b/option.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"io"
 	"net/http"
+
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // A ClientOption configures a [Client].
@@ -77,7 +79,20 @@ func WithGRPCWeb() ClientOption {
 // lowerCamelCase, zero values are omitted, missing required fields are errors,
 // enums are emitted as strings, etc.
 func WithProtoJSON() ClientOption {
-	return WithCodec(&protoJSONCodec{codecNameJSON})
+	return WithCodec(&protoJSONCodec{name: codecNameJSON})
+}
+
+// WithProtoJSONOptions is identical to WithProtoJSON, but also allows
+// protojson marshalling options to be configured.
+func WithProtoJSONOptions(
+	marshalOptions protojson.MarshalOptions,
+	unmarshalOptions protojson.UnmarshalOptions,
+) ClientOption {
+	return WithCodec(&protoJSONCodec{
+		name:             codecNameJSON,
+		marshalOptions:   marshalOptions,
+		unmarshalOptions: unmarshalOptions,
+	})
 }
 
 // WithSendCompression configures the client to use the specified algorithm to
@@ -553,7 +568,7 @@ func withProtoBinaryCodec() Option {
 
 func withProtoJSONCodecs() HandlerOption {
 	return WithHandlerOptions(
-		WithCodec(&protoJSONCodec{codecNameJSON}),
-		WithCodec(&protoJSONCodec{codecNameJSONCharsetUTF8}),
+		WithCodec(&protoJSONCodec{name: codecNameJSON}),
+		WithCodec(&protoJSONCodec{name: codecNameJSONCharsetUTF8}),
 	)
 }


### PR DESCRIPTION
r? @akshayjshah

I'd like to merge this fork from @greg-montoux / @xxgreg  into the main repository. I'm experiencing the same challenges customizing my `protojson` marshalling/unmarshalling options as proposed in: Issue https://github.com/bufbuild/connect-go/issues/477

In my specific case, I have a large body of legacy JSON APIs maintained with `lower_snake_case` and the default `camelCase` marshaling is throwing some consistency curveballs my way.

I think this option method should be available to everyone as soon as convenience allows. My alternative is to maintain a fork this repository.