### PR TITLE
Expose request method of unary requests to clients and server handlers

### DIFF
--- a/client.go
+++ b/client.go
@@ -77,6 +77,11 @@ func NewClient[Req, Res any](httpClient HTTPClient, url string, options ...Clien
 	unarySpec := config.newSpec(StreamTypeUnary)
 	unaryFunc := UnaryFunc(func(ctx context.Context, request AnyRequest) (AnyResponse, error) {
 		conn := client.protocolClient.NewConn(ctx, unarySpec, request.Header())
+		if hasRequestMethod, ok := conn.(clientConnWithRequestMethod); ok {
+			hasRequestMethod.onSetMethod(func(method string) {
+				request.setRequestMethod(method)
+			})
+		}
 		// Send always returns an io.EOF unless the error is from the client-side.
 		// We want the user to continue to call Receive in those cases to get the
 		// full error from the server-side.

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -33,6 +33,7 @@ type duplexHTTPCall struct {
 	ctx              context.Context
 	httpClient       HTTPClient
 	streamType       StreamType
+	onSetMethod      func(method string)
 	validateResponse func(*http.Response) *Error
 
 	// We'll use a pipe as the request body. We hand the read side of the pipe to
@@ -150,6 +151,9 @@ func (d *duplexHTTPCall) URL() *url.URL {
 // SetMethod changes the method of the request before it is sent.
 func (d *duplexHTTPCall) SetMethod(method string) {
 	d.request.Method = method
+	if d.onSetMethod != nil {
+		d.onSetMethod(method)
+	}
 }
 
 // Read from the response body. Returns the first error passed to SetError.

--- a/handler.go
+++ b/handler.go
@@ -67,11 +67,16 @@ func NewUnaryHandler[Req, Res any](
 		if err := conn.Receive(&msg); err != nil {
 			return err
 		}
+		method := http.MethodPost
+		if hasRequestMethod, ok := conn.(handlerConnWithRequestMethod); ok {
+			method = hasRequestMethod.getMethod()
+		}
 		request := &Request[Req]{
 			Msg:    &msg,
 			spec:   conn.Spec(),
 			peer:   conn.Peer(),
 			header: conn.RequestHeader(),
+			method: method,
 		}
 		response, err := untyped(ctx, request)
 		if err != nil {

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -499,6 +499,10 @@ func (cc *connectUnaryClientConn) CloseResponse() error {
 	return cc.duplexCall.CloseRead()
 }
 
+func (cc *connectUnaryClientConn) onSetMethod(fn func(string)) {
+	cc.duplexCall.onSetMethod = fn
+}
+
 func (cc *connectUnaryClientConn) validateResponse(response *http.Response) *Error {
 	for k, v := range response.Header {
 		if !strings.HasPrefix(k, connectUnaryTrailerPrefix) {
@@ -719,6 +723,10 @@ func (hc *connectUnaryHandlerConn) Close(err error) error {
 	return hc.request.Body.Close()
 }
 
+func (hc *connectUnaryHandlerConn) getMethod() string {
+	return hc.request.Method
+}
+
 func (hc *connectUnaryHandlerConn) writeResponseHeader(err error) {
 	header := hc.responseWriter.Header()
 	if hc.request.Method == http.MethodGet {
@@ -928,7 +936,7 @@ type connectUnaryRequestMarshaler struct {
 func (m *connectUnaryRequestMarshaler) Marshal(message any) *Error {
 	if m.enableGet {
 		if m.stableCodec == nil && !m.getUseFallback {
-			return errorf(CodeInternal, "codec %s doesn't support stable marshal; cam't use get", m.codec.Name())
+			return errorf(CodeInternal, "codec %s doesn't support stable marshal; can't use get", m.codec.Name())
 		}
 		if m.stableCodec != nil {
 			return m.marshalWithGet(message)


### PR DESCRIPTION
In order for #494 (sentinel error to return "304 not modified" status) to be safe to use, the handler actually needs to know whether the incoming request used a POST vs GET. It's only safe to use that error for GET requests.

I haven't added tests yet because I wanted to maybe get a little feedback first no whether these additions are acceptable. The primary concern is about adding another unexported method to `AnyRequest`. Also, this is very targeted to only unary RPCs (nothing in the streaming flows ever attempts to expose this since they should always be POST anyway). But I didn't know if we should try to push more of this down further into the abstractions (though that's a bit tricky since the abstractions are exported interfaces `StreamingClientConn` and `StreamingHandlerConn`...).

Anyhow, if this idea seems work-able, then I'll finish this PR out with some tests.

In addition to making the request method available to server handlers, this also makes it available to clients -- when the unary RPC completes, the caller can inspect the request's method to see if it was sent via GET or POST.

WDYT?