### PR TITLE
Always close response body in CloseRead

### DIFF
--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -180,6 +180,7 @@ func (d *duplexHTTPCall) CloseRead() error {
 		return nil
 	}
 	if err := discard(d.response.Body); err != nil {
+		_ = d.response.Body.Close()
 		return wrapIfRSTError(err)
 	}
 	return wrapIfRSTError(d.response.Body.Close())


### PR DESCRIPTION
If we fail to discard bytes, we should still close the response body.
