### PR TITLE
Prepare for v1.8.0

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.8.0-dev"
+const Version = "1.8.0"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
Prepares for the Connect v1.8.0 release, containing mostly bugfixes, but also adding an API to access the `HTTPMethod` of a request.