### PR TITLE
Discard unknown JSON fields by default

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -144,7 +144,9 @@ func (c *protoJSONCodec) Unmarshal(binary []byte, message any) error {
 	if len(binary) == 0 {
 		return errors.New("zero-length payload is not a valid JSON object")
 	}
-	var options protojson.UnmarshalOptions
+	// Discard unknown fields so clients and servers aren't forced to always use
+	// exactly the same version of the schema.
+	options := protojson.UnmarshalOptions{DiscardUnknown: true}
 	return options.Unmarshal(binary, protoMessage)
 }
 

--- a/codec_test.go
+++ b/codec_test.go
@@ -100,13 +100,22 @@ func TestStableCodec(t *testing.T) {
 func TestJSONCodec(t *testing.T) {
 	t.Parallel()
 
-	var empty emptypb.Empty
 	codec := &protoJSONCodec{name: "json"}
-	err := codec.Unmarshal([]byte{}, &empty)
-	assert.NotNil(t, err)
-	assert.True(
-		t,
-		strings.Contains(err.Error(), "valid JSON"),
-		assert.Sprintf(`error message should explain that "" is not a valid JSON object`),
-	)
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		err := codec.Unmarshal([]byte("{}"), &emptypb.Empty{})
+		assert.Nil(t, err)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		t.Parallel()
+		err := codec.Unmarshal([]byte{}, &emptypb.Empty{})
+		assert.NotNil(t, err)
+		assert.True(
+			t,
+			strings.Contains(err.Error(), "valid JSON"),
+			assert.Sprintf(`error message should explain that "" is not a valid JSON object`),
+		)
+	})
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -108,6 +108,12 @@ func TestJSONCodec(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
+	t.Run("unknown fields", func(t *testing.T) {
+		t.Parallel()
+		err := codec.Unmarshal([]byte(`{"foo": "bar"}`), &emptypb.Empty{})
+		assert.Nil(t, err)
+	})
+
 	t.Run("empty string", func(t *testing.T) {
 		t.Parallel()
 		err := codec.Unmarshal([]byte{}, &emptypb.Empty{})


### PR DESCRIPTION
The current JSON unmarshaling logic tightly couples clients and servers:
clients can't unmarshal messages containing new fields, and servers can't
unmarshal messages containing ancient fields that have since been deleted. This
is counter to the typical protobuf forward- and backward-compatibility story,
and is far more restrictive than the binary codec. This PR loosens the default
behavior to discard unknown fields.

Fixes #477.
