### PR TITLE
Lint for explicit import aliases

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,13 @@ linters-settings:
     # TODO, OPT, etc. comments are fine to commit. Use FIXME comments for
     # temporary hacks, and use godox to prevent committing them.
     keywords: [FIXME]
+  importas:
+    no-unaliased: true
+    alias:
+      - pkg: github.com/bufbuild/connect-go
+        alias: connect
+      - pkg: github.com/bufbuild/connect-go/internal/gen/connect/ping/v1
+        alias: pingv1
   varnamelen:
     ignore-decls:
       - T any

--- a/bench_test.go
+++ b/bench_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	"github.com/bufbuild/connect-go/internal/assert"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
 )

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	"github.com/bufbuild/connect-go/internal/assert"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -49,7 +49,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -32,7 +32,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	"github.com/bufbuild/connect-go/internal/assert"
 	"github.com/bufbuild/connect-go/internal/gen/connect/import/v1/importv1connect"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"

--- a/error_example_test.go
+++ b/error_example_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
 )

--- a/error_not_modified_example_test.go
+++ b/error_not_modified_example_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
 )

--- a/error_writer_example_test.go
+++ b/error_writer_example_test.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 )
 
 // NewHelloHandler is an example HTTP handler. In a real application, it might

--- a/handler_example_test.go
+++ b/handler_example_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
 )

--- a/handler_ext_test.go
+++ b/handler_ext_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	"github.com/bufbuild/connect-go/internal/assert"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"

--- a/interceptor_example_test.go
+++ b/interceptor_example_test.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"
 )

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	"github.com/bufbuild/connect-go/internal/assert"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"

--- a/recover_ext_test.go
+++ b/recover_ext_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/bufbuild/connect-go"
+	connect "github.com/bufbuild/connect-go"
 	"github.com/bufbuild/connect-go/internal/assert"
 	pingv1 "github.com/bufbuild/connect-go/internal/gen/connect/ping/v1"
 	"github.com/bufbuild/connect-go/internal/gen/connect/ping/v1/pingv1connect"


### PR DESCRIPTION
Add `connect` and `pkngv1` import aliases for packages whose name doesn't match.

similar https://github.com/bufbuild/knit-go/pull/22