### PR TITLE
Allow clients to set Host in headers

### DIFF
--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -257,6 +257,11 @@ func (d *duplexHTTPCall) makeRequest() {
 	// on d.responseReady, so we can't race with them.
 	defer close(d.responseReady)
 
+	// Promote the header Host to the request object.
+	if host := d.request.Header.Get(headerHost); len(host) > 0 {
+		d.request.Host = host
+	}
+
 	if d.onRequestSend != nil {
 		d.onRequestSend(d.request)
 	}

--- a/handler.go
+++ b/handler.go
@@ -221,6 +221,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 
 	// Establish a stream and serve the RPC.
 	setHeaderCanonical(request.Header, headerContentType, contentType)
+	setHeaderCanonical(request.Header, headerHost, request.Host)
 	ctx, cancel, timeoutErr := protocolHandler.SetTimeout(request) //nolint: contextcheck
 	if timeoutErr != nil {
 		ctx = request.Context()

--- a/handler.go
+++ b/handler.go
@@ -176,7 +176,7 @@ func NewBidiStreamHandler[Req, Res any](
 
 // ServeHTTP implements [http.Handler].
 func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
-	// We don't need to defer functions  to close the request body or read to
+	// We don't need to defer functions to close the request body or read to
 	// EOF: the stream we construct later on already does that, and we only
 	// return early when dealing with misbehaving clients. In those cases, it's
 	// okay if we can't re-use the connection.

--- a/protocol.go
+++ b/protocol.go
@@ -36,6 +36,7 @@ const (
 
 const (
 	headerContentType = "Content-Type"
+	headerHost        = "Host"
 	headerUserAgent   = "User-Agent"
 	headerTrailer     = "Trailer"
 

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -164,9 +164,6 @@ func (h *connectHandler) NewConn(
 		contentEncoding = getHeaderCanonical(request.Header, connectStreamingHeaderCompression)
 		acceptEncoding = getHeaderCanonical(request.Header, connectStreamingHeaderAcceptCompression)
 	}
-	if host := request.Host; len(host) > 0 {
-		request.Header["Host"] = []string{host}
-	}
 	requestCompression, responseCompression, failed := negotiateCompression(
 		h.CompressionPools,
 		contentEncoding,
@@ -370,9 +367,6 @@ func (c *connectClient) NewConn(
 		}
 	}
 	duplexCall := newDuplexHTTPCall(ctx, c.HTTPClient, c.URL, spec, header)
-	if hosts := header["Host"]; len(hosts) > 0 {
-		duplexCall.request.Host = hosts[0]
-	}
 	var conn streamingClientConn
 	if spec.StreamType == StreamTypeUnary {
 		unaryConn := &connectUnaryClientConn{

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -164,6 +164,9 @@ func (h *connectHandler) NewConn(
 		contentEncoding = getHeaderCanonical(request.Header, connectStreamingHeaderCompression)
 		acceptEncoding = getHeaderCanonical(request.Header, connectStreamingHeaderAcceptCompression)
 	}
+	if host := request.Host; len(host) > 0 {
+		request.Header["Host"] = []string{host}
+	}
 	requestCompression, responseCompression, failed := negotiateCompression(
 		h.CompressionPools,
 		contentEncoding,
@@ -367,6 +370,9 @@ func (c *connectClient) NewConn(
 		}
 	}
 	duplexCall := newDuplexHTTPCall(ctx, c.HTTPClient, c.URL, spec, header)
+	if hosts := header["Host"]; len(hosts) > 0 {
+		duplexCall.request.Host = hosts[0]
+	}
 	var conn streamingClientConn
 	if spec.StreamType == StreamTypeUnary {
 		unaryConn := &connectUnaryClientConn{


### PR DESCRIPTION
Allows Host to set the request.Host on the client and promotes request.Host back to a Header in the handler.

Fixes #513
