### PR TITLE
Add WithCORS handler to support CORS

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -1,0 +1,77 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+)
+
+type corsHandler struct {
+	cors *cors.Cors
+}
+
+func newCORSHandler(config CORS) *corsHandler {
+	options := cors.Options{
+		AllowedMethods: []string{
+			http.MethodGet,
+			http.MethodPost,
+		},
+		AllowedHeaders: []string{
+			"Content-Type",
+			"Connect-Protocol-Version",
+			"Connect-Timeout-Ms",
+			"Connect-Accept-Encoding",  // future use
+			"Connect-Content-Encoding", // future use
+			"Accept-Encoding",          // future use
+			"Content-Encoding",         // future use
+			"Grpc-Timeout",             // gRPC-web
+			"X-Grpc-Web",               // gRPC-web
+			"X-User-Agent",             // gRPC-web
+		},
+		ExposedHeaders: []string{
+			"Content-Encoding",
+			"Connect-Content-Encoding",
+			"Grpc-Status",             // gRPC-web
+			"Grpc-Message",            // gRPC-web
+			"Grpc-Status-Details-Bin", // gRPC, gRPC-web
+		},
+	}
+
+	options.AllowOriginFunc = config.AllowOriginFunc
+	options.AllowedHeaders = append(options.AllowedHeaders, config.AllowedHeaders...)
+	options.ExposedHeaders = append(options.ExposedHeaders, config.ExposedHeaders...)
+	options.MaxAge = config.MaxAge
+	options.AllowCredentials = config.AllowCredentials
+
+	return &corsHandler{
+		cors: cors.New(options),
+	}
+}
+
+func (c *corsHandler) applyToHandler(config *handlerConfig) {
+	config.CORSHandler = c
+}
+
+func isPreflight(r *http.Request) bool {
+	return r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != ""
+}
+
+// handle handles CORS for the request, returning true if the request is done.
+func (c *corsHandler) handle(w http.ResponseWriter, r *http.Request) (done bool) {
+	c.cors.HandlerFunc(w, r)
+	return isPreflight(r)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/google/go-cmp v0.5.9
 	google.golang.org/protobuf v1.28.1
 )
+
+require github.com/rs/cors v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
+github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=

--- a/handler.go
+++ b/handler.go
@@ -95,7 +95,7 @@ func NewUnaryHandler[Req, Res any](
 		protocolHandlers: protocolHandlers,
 		allowMethod:      sortedAllowMethodValue(protocolHandlers),
 		acceptPost:       sortedAcceptPostValue(protocolHandlers),
-		corsHandler:      config.CORSHandler,
+		corsHandler:      config.CORS.wrap(protocolHandlers),
 	}
 }
 
@@ -268,7 +268,7 @@ type handlerConfig struct {
 	BufferPool                   *bufferPool
 	ReadMaxBytes                 int
 	SendMaxBytes                 int
-	CORSHandler                  *corsHandler
+	CORS                         *CORS
 }
 
 func newHandlerConfig(procedure string, options []HandlerOption) *handlerConfig {
@@ -345,6 +345,6 @@ func newStreamHandler(
 		protocolHandlers: protocolHandlers,
 		allowMethod:      sortedAllowMethodValue(protocolHandlers),
 		acceptPost:       sortedAcceptPostValue(protocolHandlers),
-		corsHandler:      config.CORSHandler,
+		corsHandler:      config.CORS.wrap(protocolHandlers),
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -95,6 +95,7 @@ func NewUnaryHandler[Req, Res any](
 		protocolHandlers: protocolHandlers,
 		allowMethod:      sortedAllowMethodValue(protocolHandlers),
 		acceptPost:       sortedAcceptPostValue(protocolHandlers),
+		corsHandler:      config.CORSHandler,
 	}
 }
 

--- a/handler_ext_test.go
+++ b/handler_ext_test.go
@@ -248,7 +248,6 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		defer resp.Body.Close()
 		assert.Equal(t, resp.StatusCode, http.StatusNoContent)
 		assert.Equal(t, resp.Header.Get("Access-Control-Allow-Origin"), "")
-
 	})
 }
 

--- a/option.go
+++ b/option.go
@@ -166,35 +166,6 @@ func WithRequireConnectProtocolHeader() HandlerOption {
 	return &requireConnectProtocolHeaderOption{}
 }
 
-// CORS config that adds Cross-Origin Resource Sharing (CORS) header support.
-type CORS struct {
-	// AllowOriginFunc is a custom function to validate the origin. It take the
-	// origin as argument and returns true if allowed or false otherwise.
-	AllowOriginFunc func(origin string) bool
-
-	// AllowedMethods is a list of methods the client is allowed to use with
-	// cross-domain requests. Default value is simple methods (GET and POST).
-	AllowedMethods []string
-
-	// AllowedHeaders is list of non simple headers the client is allowed to
-	// use with cross-domain requests.
-	AllowedHeaders []string
-
-	// ExposedHeaders indicates which headers are safe to expose to the API of
-	// AllowHeaders.ExposedHeaders is ignored if the request's
-	// Access-Control-Request-Headers header is empty.
-	ExposedHeaders []string
-
-	// MaxAge indicates how long (in seconds) the results of a preflight request
-	// can be cached. Default value is 0 which means that the request is not
-	// cached.
-	MaxAge int
-
-	// AllowCredentials indicates whether the request can include user credentials like
-	// cookies, HTTP authentication or client side SSL certificates.
-	AllowCredentials bool
-}
-
 // WithCORS configures a handler to support Cross-Origin Resource Sharing
 // (CORS). The handler will respond to preflight requests and add CORS headers
 // to all responses.
@@ -202,9 +173,7 @@ type CORS struct {
 // By default, handlers don't support CORS.
 //
 // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
-func WithCORS(config CORS) HandlerOption {
-	return newCORSHandler(config)
-}
+func WithCORS(config CORS) HandlerOption { return config }
 
 // Option implements both [ClientOption] and [HandlerOption], so it can be
 // applied both client-side and server-side.

--- a/option.go
+++ b/option.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"time"
 )
 
 // A ClientOption configures a [Client].

--- a/option.go
+++ b/option.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"time"
 )
 
 // A ClientOption configures a [Client].
@@ -164,6 +165,46 @@ func WithRecover(handle func(context.Context, Spec, http.Header, any) error) Han
 // This option has no effect if the client uses the gRPC or gRPC-Web protocols.
 func WithRequireConnectProtocolHeader() HandlerOption {
 	return &requireConnectProtocolHeaderOption{}
+}
+
+// CORS config that adds Cross-Origin Resource Sharing (CORS) header support.
+type CORS struct {
+	// AllowOriginFunc is a custom function to validate the origin. It take the
+	// origin as argument and returns true if allowed or false otherwise.
+	AllowOriginFunc func(origin string) bool
+
+	// AllowedMethods is a list of methods the client is allowed to use with
+	// cross-domain requests. Default value is simple methods (GET and POST).
+	AllowedMethods []string
+
+	// AllowedHeaders is list of non simple headers the client is allowed to
+	// use with cross-domain requests.
+	AllowedHeaders []string
+
+	// ExposedHeaders indicates which headers are safe to expose to the API of
+	// AllowHeaders.ExposedHeaders is ignored if the request's
+	// Access-Control-Request-Headers header is empty.
+	ExposedHeaders []string
+
+	// MaxAge indicates how long (in seconds) the results of a preflight request
+	// can be cached. Default value is 0 which means that the request is not
+	// cached.
+	MaxAge int
+
+	// AllowCredentials indicates whether the request can include user credentials like
+	// cookies, HTTP authentication or client side SSL certificates.
+	AllowCredentials bool
+}
+
+// WithCORS configures a handler to support Cross-Origin Resource Sharing
+// (CORS). The handler will respond to preflight requests and add CORS headers
+// to all responses.
+//
+// By default, handlers don't support CORS.
+//
+// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+func WithCORS(config CORS) HandlerOption {
+	return newCORSHandler(config)
 }
 
 // Option implements both [ClientOption] and [HandlerOption], so it can be


### PR DESCRIPTION
Implements a new handler option WithCORS to add support for CORS preflight and headers. AllowedMethods are taken from the protocol handlers and custom headers are exposed through the config option CORS.

Implemented with rs/cors.

Fixes https://github.com/bufbuild/connect-go/issues/499