### PR TITLE
Canonicalize Connect Streaming Trailer names

### DIFF
--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -864,6 +864,13 @@ func (u *connectStreamingUnmarshaler) Unmarshal(message any) *Error {
 	if err := json.Unmarshal(env.Data.Bytes(), &end); err != nil {
 		return errorf(CodeInternal, "unmarshal end stream message: %w", err)
 	}
+	for name, value := range end.Trailer {
+		canonical := http.CanonicalHeaderKey(name)
+		if name != canonical {
+			delete(end.Trailer, name)
+			end.Trailer[canonical] = append(end.Trailer[canonical], value...)
+		}
+	}
 	u.trailer = end.Trailer
 	u.endStreamErr = end.Error.asError()
 	return errSpecialEnvelope


### PR DESCRIPTION
After testing many approaches, I think this is the most reasonable one. At least with Go JSON, there is no reasonable approach I could find that will give better performance or memory allocation characteristics to do this in one single pass. This approach should also have a _relatively_ small impact on trailers that are already canonicalized, since they will trivially fall into the `CanonicalMIMEHeaderKey` fast-path. The impact on the response path will probably be measured in hundreds of nanoseconds to microseconds in most cases, which is not ideal, but we definitely have bigger fish to fry, and correctness is important.

Closes #524.