### PR TITLE
Export max URL size option

### DIFF
--- a/client_get_fallback_test.go
+++ b/client_get_fallback_test.go
@@ -47,7 +47,7 @@ func TestClientUnaryGetFallback(t *testing.T) {
 		server.Client(),
 		server.URL+"/connect.ping.v1.PingService/Ping",
 		WithHTTPGet(),
-		withHTTPGetMaxURLSize(1, true),
+		WithHTTPGetMaxURLSize(1, true),
 		WithSendGzip(),
 	)
 	ctx := context.Background()

--- a/option.go
+++ b/option.go
@@ -456,7 +456,7 @@ func (o *enableGet) applyToClient(config *clientConfig) {
 	config.EnableGet = true
 }
 
-// withHTTPGetMaxURLSize sets the maximum allowable URL length for GET requests
+// WithHTTPGetMaxURLSize sets the maximum allowable URL length for GET requests
 // made using the Connect protocol. It has no effect on gRPC or gRPC-Web
 // clients, since those protocols are POST-only.
 //
@@ -474,7 +474,7 @@ func (o *enableGet) applyToClient(config *clientConfig) {
 //
 // By default, Connect-protocol clients with GET requests enabled may send a
 // URL of any size.
-func withHTTPGetMaxURLSize(bytes int, fallback bool) ClientOption {
+func WithHTTPGetMaxURLSize(bytes int, fallback bool) ClientOption {
 	return &getURLMaxBytes{Max: bytes, Fallback: fallback}
 }
 


### PR DESCRIPTION
Was this unexported on purpose? This seems like a very valuable option for anyone that wants to actually use HTTP GET requests. Also, it was fully specified as if it was exported, even though it was unexported and used by a single test case.