### PR TITLE
Use strings.Builder for gRPC percent methods

### DIFF
--- a/error_writer.go
+++ b/error_writer.go
@@ -145,7 +145,7 @@ func (w *ErrorWriter) writeConnectStreaming(response http.ResponseWriter, err er
 
 func (w *ErrorWriter) writeGRPC(response http.ResponseWriter, err error) error {
 	trailers := make(http.Header, 2) // need space for at least code & message
-	grpcErrorToTrailer(w.bufferPool, trailers, w.protobuf, err)
+	grpcErrorToTrailer(trailers, w.protobuf, err)
 	// To make net/http reliably send trailers without a body, we must set the
 	// Trailers header rather than using http.TrailerPrefix. See
 	// https://github.com/golang/go/issues/54723.
@@ -162,7 +162,7 @@ func (w *ErrorWriter) writeGRPC(response http.ResponseWriter, err error) error {
 func (w *ErrorWriter) writeGRPCWeb(response http.ResponseWriter, err error) error {
 	// This is a trailers-only response. To match the behavior of Envoy and
 	// protocol_grpc.go, put the trailers in the HTTP headers.
-	grpcErrorToTrailer(w.bufferPool, response.Header(), w.protobuf, err)
+	grpcErrorToTrailer(response.Header(), w.protobuf, err)
 	response.WriteHeader(http.StatusOK)
 	return nil
 }

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -388,7 +388,7 @@ func (cc *grpcClientConn) Receive(msg any) error {
 		cc.responseTrailer,
 		cc.readTrailers(&cc.unmarshaler, cc.duplexCall),
 	)
-	serverErr := grpcErrorFromTrailer(cc.bufferPool, cc.protobuf, cc.responseTrailer)
+	serverErr := grpcErrorFromTrailer(cc.protobuf, cc.responseTrailer)
 	if serverErr != nil && (errors.Is(err, io.EOF) || !errors.Is(serverErr, errTrailersWithoutGRPCStatus)) {
 		// We've either:
 		//   - Cleanly read until the end of the response body and *not* received
@@ -434,7 +434,6 @@ func (cc *grpcClientConn) validateResponse(response *http.Response) *Error {
 		cc.responseHeader,
 		cc.responseTrailer,
 		cc.compressionPools,
-		cc.bufferPool,
 		cc.protobuf,
 	); err != nil {
 		return err
@@ -524,7 +523,7 @@ func (hc *grpcHandlerConn) Close(err error) (retErr error) {
 		len(hc.responseTrailer)+2, // always make space for status & message
 	)
 	mergeHeaders(mergedTrailers, hc.responseTrailer)
-	grpcErrorToTrailer(hc.bufferPool, mergedTrailers, hc.protobuf, err)
+	grpcErrorToTrailer(mergedTrailers, hc.protobuf, err)
 	if hc.web && !hc.wroteToBody {
 		// We're using gRPC-Web and we haven't yet written to the body. Since we're
 		// not sending any response messages, the gRPC specification calls this a
@@ -661,7 +660,6 @@ func grpcValidateResponse(
 	response *http.Response,
 	header, trailer http.Header,
 	availableCompressors readOnlyCompressionPools,
-	bufferPool *bufferPool,
 	protobuf Codec,
 ) *Error {
 	if response.StatusCode != http.StatusOK {
@@ -683,7 +681,6 @@ func grpcValidateResponse(
 	// When there's no body, gRPC and gRPC-Web servers may send error information
 	// in the HTTP headers.
 	if err := grpcErrorFromTrailer(
-		bufferPool,
 		protobuf,
 		response.Header,
 	); err != nil && !errors.Is(err, errTrailersWithoutGRPCStatus) {
@@ -729,7 +726,7 @@ func grpcHTTPToCode(httpCode int) Code {
 // binary Protobuf format, even if the messages in the request/response stream
 // use a different codec. Consequently, this function needs a Protobuf codec to
 // unmarshal error information in the headers.
-func grpcErrorFromTrailer(bufferPool *bufferPool, protobuf Codec, trailer http.Header) *Error {
+func grpcErrorFromTrailer(protobuf Codec, trailer http.Header) *Error {
 	codeHeader := getHeaderCanonical(trailer, grpcHeaderStatus)
 	if codeHeader == "" {
 		return NewError(CodeInternal, errTrailersWithoutGRPCStatus)
@@ -742,7 +739,7 @@ func grpcErrorFromTrailer(bufferPool *bufferPool, protobuf Codec, trailer http.H
 	if err != nil {
 		return errorf(CodeInternal, "gRPC protocol error: invalid error code %q", codeHeader)
 	}
-	message := grpcPercentDecode(bufferPool, getHeaderCanonical(trailer, grpcHeaderMessage))
+	message := grpcPercentDecode(getHeaderCanonical(trailer, grpcHeaderMessage))
 	retErr := NewWireError(Code(code), errors.New(message))
 
 	detailsBinaryEncoded := getHeaderCanonical(trailer, grpcHeaderDetails)
@@ -823,7 +820,7 @@ func grpcContentTypeFromCodecName(web bool, name string) string {
 	return grpcContentTypePrefix + name
 }
 
-func grpcErrorToTrailer(bufferPool *bufferPool, trailer http.Header, protobuf Codec, err error) {
+func grpcErrorToTrailer(trailer http.Header, protobuf Codec, err error) {
 	if err == nil {
 		setHeaderCanonical(trailer, grpcHeaderStatus, "0") // zero is the gRPC OK status
 		setHeaderCanonical(trailer, grpcHeaderMessage, "")
@@ -842,7 +839,6 @@ func grpcErrorToTrailer(bufferPool *bufferPool, trailer http.Header, protobuf Co
 			trailer,
 			grpcHeaderMessage,
 			grpcPercentEncode(
-				bufferPool,
 				fmt.Sprintf("marshal protobuf status: %v", binErr),
 			),
 		)
@@ -852,7 +848,7 @@ func grpcErrorToTrailer(bufferPool *bufferPool, trailer http.Header, protobuf Co
 		mergeHeaders(trailer, connectErr.meta)
 	}
 	setHeaderCanonical(trailer, grpcHeaderStatus, code)
-	setHeaderCanonical(trailer, grpcHeaderMessage, grpcPercentEncode(bufferPool, status.Message))
+	setHeaderCanonical(trailer, grpcHeaderMessage, grpcPercentEncode(status.Message))
 	setHeaderCanonical(trailer, grpcHeaderDetails, EncodeBinaryHeader(bin))
 }
 
@@ -881,12 +877,12 @@ func grpcStatusFromError(err error) *statusv1.Status {
 //
 //	https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
 //	https://datatracker.ietf.org/doc/html/rfc3986#section-2.1
-func grpcPercentEncode(bufferPool *bufferPool, msg string) string {
+func grpcPercentEncode(msg string) string {
 	for i := 0; i < len(msg); i++ {
 		// Characters that need to be escaped are defined in gRPC's HTTP/2 spec.
 		// They're different from the generic set defined in RFC 3986.
 		if c := msg[i]; c < ' ' || c > '~' || c == '%' {
-			return grpcPercentEncodeSlow(bufferPool, msg, i)
+			return grpcPercentEncodeSlow(msg, i)
 		}
 	}
 	return msg
@@ -894,14 +890,14 @@ func grpcPercentEncode(bufferPool *bufferPool, msg string) string {
 
 // msg needs some percent-escaping. Bytes before offset don't require
 // percent-encoding, so they can be copied to the output as-is.
-func grpcPercentEncodeSlow(bufferPool *bufferPool, msg string, offset int) string {
-	out := bufferPool.Get()
-	defer bufferPool.Put(out)
+func grpcPercentEncodeSlow(msg string, offset int) string {
+	var out strings.Builder
+	out.Grow(2 * len(msg))
 	out.WriteString(msg[:offset])
 	for i := offset; i < len(msg); i++ {
 		c := msg[i]
 		if c < ' ' || c > '~' || c == '%' {
-			out.WriteString(fmt.Sprintf("%%%02X", c))
+			fmt.Fprintf(&out, "%%%02X", c)
 			continue
 		}
 		out.WriteByte(c)
@@ -909,10 +905,10 @@ func grpcPercentEncodeSlow(bufferPool *bufferPool, msg string, offset int) strin
 	return out.String()
 }
 
-func grpcPercentDecode(bufferPool *bufferPool, encoded string) string {
+func grpcPercentDecode(encoded string) string {
 	for i := 0; i < len(encoded); i++ {
 		if c := encoded[i]; c == '%' && i+2 < len(encoded) {
-			return grpcPercentDecodeSlow(bufferPool, encoded, i)
+			return grpcPercentDecodeSlow(encoded, i)
 		}
 	}
 	return encoded
@@ -920,9 +916,9 @@ func grpcPercentDecode(bufferPool *bufferPool, encoded string) string {
 
 // Similar to percentEncodeSlow: encoded is percent-encoded, and needs to be
 // decoded byte-by-byte starting at offset.
-func grpcPercentDecodeSlow(bufferPool *bufferPool, encoded string, offset int) string {
-	out := bufferPool.Get()
-	defer bufferPool.Put(out)
+func grpcPercentDecodeSlow(encoded string, offset int) string {
+	var out strings.Builder
+	out.Grow(len(encoded))
 	out.WriteString(encoded[:offset])
 	for i := offset; i < len(encoded); i++ {
 		c := encoded[i]


### PR DESCRIPTION
Both `grpcPercentEncode` and `grpcPercentDecode` need to allocate a string and can use `strings.Builder` to own the allocation. Small optimization with `Grow` to give a hint to the size. 

```
goos: darwin
goarch: arm64
pkg: github.com/bufbuild/connect-go
                      │ current.txt  │                new.txt                │
                      │    sec/op    │    sec/op     vs base                 │
GRPCPercentEncoding-8   408.6n ± ∞ ¹   371.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
GRPCPercentDecoding-8   79.59n ± ∞ ¹   65.24n ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                 180.3n         155.7n        -13.65%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                      │ current.txt │               new.txt                │
                      │    B/op     │    B/op      vs base                 │
GRPCPercentEncoding-8   51.00 ± ∞ ¹   64.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
GRPCPercentDecoding-8   16.00 ± ∞ ¹   32.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                 28.57         45.25        +58.42%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                      │ current.txt │               new.txt                │
                      │  allocs/op  │  allocs/op   vs base                 │
GRPCPercentEncoding-8   7.000 ± ∞ ¹   2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
GRPCPercentDecoding-8   1.000 ± ∞ ¹   1.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
geomean                 2.646         1.414        -46.55%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal
```