### PR TITLE
Simplify code when pooled buffers aren't returned

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -171,14 +171,11 @@ func (r *envelopeReader) Unmarshal(message any) *Error {
 		// stream. Save the message for protocol-specific code to process and
 		// return a sentinel error. Since we've deferred functions to return env's
 		// underlying buffer to a pool, we need to keep a copy.
+		copiedData := make([]byte, data.Len())
+		copy(copiedData, data.Bytes())
 		r.last = envelope{
-			Data:  r.bufferPool.Get(),
+			Data:  bytes.NewBuffer(copiedData),
 			Flags: env.Flags,
-		}
-		// Don't return last to the pool! We're going to reference the data
-		// elsewhere.
-		if _, err := r.last.Data.ReadFrom(data); err != nil {
-			return errorf(CodeUnknown, "copy final envelope: %w", err)
 		}
 		return errSpecialEnvelope
 	}


### PR DESCRIPTION
In some error handling cases, we're retrieving a value from the sync.Pool and explicitly not returning it. Instead, we might simplify things and just allocate a buffer (since we already know the size) and use it and not put extra work on the pool to garbage collect objects that are retrieved but never returned.
