### PR TITLE
Capture unexpected io.EOF errors as io.ErrUnexpectedEOF

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -246,6 +246,9 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 			// We're reading from an http.MaxBytesHandler, and we've exceeded the read limit.
 			return maxBytesErr
 		}
+		if err == nil {
+			err = io.ErrUnexpectedEOF
+		}
 		return errorf(
 			CodeInvalidArgument,
 			"protocol error: incomplete envelope: %w", err,

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -606,6 +606,11 @@ func (cc *connectStreamingClientConn) Receive(msg any) error {
 		cc.duplexCall.SetError(serverErr)
 		return serverErr
 	}
+	// If the error is EOF but not from a last message, we want to return
+	// io.ErrUnexpectedEOF instead.
+	if errors.Is(err, io.EOF) && !errors.Is(err, errSpecialEnvelope) {
+		err = NewError(CodeUnknown, io.ErrUnexpectedEOF)
+	}
 	// There's no error in the trailers, so this was probably an error
 	// converting the bytes to a message, an error reading from the network, or
 	// just an EOF. We're going to return it to the user, but we also want to


### PR DESCRIPTION
On [Unmarshal](https://github.com/bufbuild/connect-go/blob/929c254ef86fbd5a131f0740fff25971fc65befa/envelope.go#L235-L239) we return `io.EOF` if there is no envelope header. The `errSpecialEnvelope` wraps `io.EOF` and is used in client code to check for [stream errors](https://github.com/bufbuild/connect-go/blob/929c254ef86fbd5a131f0740fff25971fc65befa/client_stream.go#L135-L137). To distinguish between them we can instead check on `Receive` streams if the error is not a known `errSpecialEnvelope`  and return an `io.ErrUnexpectedEOF`.

Fixes https://github.com/bufbuild/connect-go/issues/397
