### PR TITLE
Drain stream and error on trailing data

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2259,12 +2259,9 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			request.Header().Set("Test-Case", t.Name())
 			stream, err := client.CountUp(context.Background(), request)
 			assert.Nil(t, err)
-			for i := 0; stream.Receive() && i < upTo; i += 1 {
+			for i := 0; stream.Receive() && i < upTo; i++ {
 				assert.Equal(t, stream.Msg().Number, 42)
 			}
-			t.Log(stream.Err())
-			closeErr := stream.Close()
-			t.Log(closeErr)
 			assert.NotNil(t, stream.Err())
 			assert.Equal(t, connect.CodeOf(stream.Err()), testcase.expectCode)
 			assert.Equal(t, stream.Err().Error(), testcase.expectMsg)

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2115,8 +2115,10 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
 			header := responseWriter.Header()
 			header.Set("Content-Type", "application/connect+json")
-			_, _ = responseWriter.Write(head[:])
-			_, _ = responseWriter.Write(payload)
+			_, err := responseWriter.Write(head[:])
+			assert.Nil(t, err)
+			_, err = responseWriter.Write(payload)
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInternal,
 		expectMsg:  "internal: protocol error: unexpected EOF",
@@ -2126,8 +2128,10 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
 			header := responseWriter.Header()
 			header.Set("Content-Type", "application/grpc+json")
-			_, _ = responseWriter.Write(head[:])
-			_, _ = responseWriter.Write(payload)
+			_, err := responseWriter.Write(head[:])
+			assert.Nil(t, err)
+			_, err = responseWriter.Write(payload)
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInternal,
 		expectMsg:  "internal: protocol error: no Grpc-Status trailer: unexpected EOF",
@@ -2137,8 +2141,10 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
 			header := responseWriter.Header()
 			header.Set("Content-Type", "application/grpc-web+json")
-			_, _ = responseWriter.Write(head[:])
+			_, err := responseWriter.Write(head[:])
+			assert.Nil(t, err)
 			_, _ = responseWriter.Write(payload)
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInternal,
 		expectMsg:  "internal: protocol error: no Grpc-Status trailer: unexpected EOF",
@@ -2148,8 +2154,10 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
 			header := responseWriter.Header()
 			header.Set("Content-Type", "application/connect+json")
-			_, _ = responseWriter.Write(head[:])
-			_, _ = responseWriter.Write(payload[:len(payload)-1])
+			_, err := responseWriter.Write(head[:])
+			assert.Nil(t, err)
+			_, err = responseWriter.Write(payload[:len(payload)-1])
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInvalidArgument,
 		expectMsg:  fmt.Sprintf("invalid_argument: protocol error: promised %d bytes in enveloped message, got %d bytes", len(payload), len(payload)-1),
@@ -2159,8 +2167,10 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
 			header := responseWriter.Header()
 			header.Set("Content-Type", "application/grpc+json")
-			_, _ = responseWriter.Write(head[:])
-			_, _ = responseWriter.Write(payload[:len(payload)-1])
+			_, err := responseWriter.Write(head[:])
+			assert.Nil(t, err)
+			_, err = responseWriter.Write(payload[:len(payload)-1])
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInvalidArgument,
 		expectMsg:  fmt.Sprintf("invalid_argument: protocol error: promised %d bytes in enveloped message, got %d bytes", len(payload), len(payload)-1),
@@ -2170,8 +2180,10 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
 			header := responseWriter.Header()
 			header.Set("Content-Type", "application/grpc-web+json")
-			_, _ = responseWriter.Write(head[:])
-			_, _ = responseWriter.Write(payload[:len(payload)-1])
+			_, err := responseWriter.Write(head[:])
+			assert.Nil(t, err)
+			_, err = responseWriter.Write(payload[:len(payload)-1])
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInvalidArgument,
 		expectMsg:  fmt.Sprintf("invalid_argument: protocol error: promised %d bytes in enveloped message, got %d bytes", len(payload), len(payload)-1),
@@ -2181,7 +2193,8 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
 			header := responseWriter.Header()
 			header.Set("Content-Type", "application/connect+json")
-			_, _ = responseWriter.Write(head[:4])
+			_, err := responseWriter.Write(head[:4])
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInvalidArgument,
 		expectMsg:  "invalid_argument: protocol error: incomplete envelope: unexpected EOF",
@@ -2191,7 +2204,8 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
 			header := responseWriter.Header()
 			header.Set("Content-Type", "application/grpc+json")
-			_, _ = responseWriter.Write(head[:4])
+			_, err := responseWriter.Write(head[:4])
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInvalidArgument,
 		expectMsg:  "invalid_argument: protocol error: incomplete envelope: unexpected EOF",
@@ -2201,43 +2215,56 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
 			header := responseWriter.Header()
 			header.Set("Content-Type", "application/grpc-web+json")
-			_, _ = responseWriter.Write(head[:4])
+			_, err := responseWriter.Write(head[:4])
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInvalidArgument,
 		expectMsg:  "invalid_argument: protocol error: incomplete envelope: unexpected EOF",
 	}, {
 		name:    "connect_excess_eof",
 		options: []connect.ClientOption{connect.WithProtoJSON()},
-		handler: func(responseWriter http.ResponseWriter, request *http.Request) {
-			_, _ = responseWriter.Write(head[:])
-			_, _ = responseWriter.Write(payload)
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			_, err := responseWriter.Write(head[:])
+			assert.Nil(t, err)
+			_, err = responseWriter.Write(payload)
+			assert.Nil(t, err)
 			// Write EOF
-			_, _ = responseWriter.Write([]byte{1 << 1, 0, 0, 0, 2})
-			_, _ = responseWriter.Write([]byte("{}"))
+			_, err = responseWriter.Write([]byte{1 << 1, 0, 0, 0, 2})
+			assert.Nil(t, err)
+			_, err = responseWriter.Write([]byte("{}"))
+			assert.Nil(t, err)
 			// Excess payload
-			_, _ = responseWriter.Write(head[:])
-			_, _ = responseWriter.Write(payload)
+			_, err = responseWriter.Write(head[:])
+			assert.Nil(t, err)
+			_, err = responseWriter.Write(payload)
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInternal,
 		expectMsg:  fmt.Sprintf("internal: corrupt response: %d extra bytes after end of stream", len(payload)+len(head)),
 	}, {
 		name:    "grpc-web_excess_eof",
 		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPCWeb()},
-		handler: func(responseWriter http.ResponseWriter, request *http.Request) {
-			_, _ = responseWriter.Write(head[:])
-			_, _ = responseWriter.Write(payload)
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			_, err := responseWriter.Write(head[:])
+			assert.Nil(t, err)
+			_, err = responseWriter.Write(payload)
+			assert.Nil(t, err)
 			// Write EOF
 			var buf bytes.Buffer
 			trailer := http.Header{"grpc-status": []string{"0"}}
-			_ = trailer.Write(&buf)
+			assert.Nil(t, trailer.Write(&buf))
 			var head [5]byte
 			head[0] = 1 << 7
 			binary.BigEndian.PutUint32(head[1:], uint32(buf.Len()))
-			_, _ = responseWriter.Write(head[:])
-			_, _ = responseWriter.Write(buf.Bytes())
+			_, err = responseWriter.Write(head[:])
+			assert.Nil(t, err)
+			_, err = responseWriter.Write(buf.Bytes())
+			assert.Nil(t, err)
 			// Excess payload
-			_, _ = responseWriter.Write(head[:])
-			_, _ = responseWriter.Write(payload)
+			_, err = responseWriter.Write(head[:])
+			assert.Nil(t, err)
+			_, err = responseWriter.Write(payload)
+			assert.Nil(t, err)
 		},
 		expectCode: connect.CodeInternal,
 		expectMsg:  fmt.Sprintf("internal: corrupt response: %d extra bytes after end of stream", len(payload)+len(head)),

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -179,7 +179,7 @@ func (d *duplexHTTPCall) CloseRead() error {
 	if d.response == nil {
 		return nil
 	}
-	if err := discard(d.response.Body); err != nil {
+	if _, err := discard(d.response.Body); err != nil {
 		_ = d.response.Body.Close()
 		return wrapIfRSTError(err)
 	}

--- a/envelope.go
+++ b/envelope.go
@@ -209,6 +209,12 @@ func (r *envelopeReader) Unmarshal(message any) *Error {
 			Data:  bytes.NewBuffer(copiedData),
 			Flags: env.Flags,
 		}
+		// Drain the rest of the stream to ensure there is no extra data.
+		if n, err := discard(r.reader); err != nil {
+			return errorf(CodeUnknown, "corrupt response: I/O error after end-stream message: %w", err)
+		} else if n > 0 {
+			return errorf(CodeUnknown, "corrupt response: %d extra bytes after end of stream", n)
+		}
 		return errSpecialEnvelope
 	}
 

--- a/envelope.go
+++ b/envelope.go
@@ -211,9 +211,9 @@ func (r *envelopeReader) Unmarshal(message any) *Error {
 		}
 		// Drain the rest of the stream to ensure there is no extra data.
 		if n, err := discard(r.reader); err != nil {
-			return errorf(CodeUnknown, "corrupt response: I/O error after end-stream message: %w", err)
+			return errorf(CodeInternal, "corrupt response: I/O error after end-stream message: %w", err)
 		} else if n > 0 {
-			return errorf(CodeUnknown, "corrupt response: %d extra bytes after end of stream", n)
+			return errorf(CodeInternal, "corrupt response: %d extra bytes after end of stream", n)
 		}
 		return errSpecialEnvelope
 	}

--- a/protocol.go
+++ b/protocol.go
@@ -283,16 +283,14 @@ func isCommaOrSpace(c rune) bool {
 	return c == ',' || c == ' '
 }
 
-func discard(reader io.Reader) error {
+func discard(reader io.Reader) (int64, error) {
 	if lr, ok := reader.(*io.LimitedReader); ok {
-		_, err := io.Copy(io.Discard, lr)
-		return err
+		return io.Copy(io.Discard, lr)
 	}
 	// We don't want to get stuck throwing data away forever, so limit how much
 	// we're willing to do here.
 	lr := &io.LimitedReader{R: reader, N: discardLimit}
-	_, err := io.Copy(io.Discard, lr)
-	return err
+	return io.Copy(io.Discard, lr)
 }
 
 // negotiateCompression determines and validates the request compression and

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -325,8 +325,6 @@ func (g *grpcClient) NewConn(
 		}
 	} else {
 		conn.readTrailers = func(_ *grpcUnmarshaler, call *duplexHTTPCall) http.Header {
-			// To access HTTP trailers, we need to read the body to EOF.
-			_, _ = discard(call)
 			return call.ResponseTrailer()
 		}
 	}

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -325,6 +325,8 @@ func (g *grpcClient) NewConn(
 		}
 	} else {
 		conn.readTrailers = func(_ *grpcUnmarshaler, call *duplexHTTPCall) http.Header {
+			// To access HTTP trailers, we need to read the body to EOF.
+			_, _ = discard(call)
 			return call.ResponseTrailer()
 		}
 	}

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -326,7 +326,7 @@ func (g *grpcClient) NewConn(
 	} else {
 		conn.readTrailers = func(_ *grpcUnmarshaler, call *duplexHTTPCall) http.Header {
 			// To access HTTP trailers, we need to read the body to EOF.
-			_ = discard(call)
+			_, _ = discard(call)
 			return call.ResponseTrailer()
 		}
 	}


### PR DESCRIPTION
For connect and gRPC-web on receiving end of stream payloads ensure no extra data is written by draining the reader and erroring on more data.

Extension of https://github.com/bufbuild/connect-go/pull/533

Fixes https://github.com/bufbuild/connect-go/issues/427