### PR TITLE
Add WithConditionalHandlerOptions for conditional options

### DIFF
--- a/compression_test.go
+++ b/compression_test.go
@@ -128,35 +128,35 @@ func TestHandlerCompressionOptionTest(t *testing.T) {
 
 	t.Run("defaults", func(t *testing.T) {
 		t.Parallel()
-		config := newHandlerConfig(testProc, nil)
+		config := newHandlerConfig(testProc, StreamTypeUnary, nil)
 		assert.Equal(t, config.CompressionNames, []string{compressionGzip})
 		checkPools(t, config)
 	})
 	t.Run("WithCompression", func(t *testing.T) {
 		t.Parallel()
 		opts := []HandlerOption{WithCompression("foo", dummyDecompressCtor, dummyCompressCtor)}
-		config := newHandlerConfig(testProc, opts)
+		config := newHandlerConfig(testProc, StreamTypeUnary, opts)
 		assert.Equal(t, config.CompressionNames, []string{compressionGzip, "foo"})
 		checkPools(t, config)
 	})
 	t.Run("WithCompression-empty-name-noop", func(t *testing.T) {
 		t.Parallel()
 		opts := []HandlerOption{WithCompression("", dummyDecompressCtor, dummyCompressCtor)}
-		config := newHandlerConfig(testProc, opts)
+		config := newHandlerConfig(testProc, StreamTypeUnary, opts)
 		assert.Equal(t, config.CompressionNames, []string{compressionGzip})
 		checkPools(t, config)
 	})
 	t.Run("WithCompression-nil-ctors-noop", func(t *testing.T) {
 		t.Parallel()
 		opts := []HandlerOption{WithCompression("foo", nil, nil)}
-		config := newHandlerConfig(testProc, opts)
+		config := newHandlerConfig(testProc, StreamTypeUnary, opts)
 		assert.Equal(t, config.CompressionNames, []string{compressionGzip})
 		checkPools(t, config)
 	})
 	t.Run("WithCompression-nil-ctors-unregisters", func(t *testing.T) {
 		t.Parallel()
 		opts := []HandlerOption{WithCompression("gzip", nil, nil)}
-		config := newHandlerConfig(testProc, opts)
+		config := newHandlerConfig(testProc, StreamTypeUnary, opts)
 		assert.Equal(t, config.CompressionNames, nil)
 		checkPools(t, config)
 	})

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -1001,7 +1001,12 @@ func TestHandlerWithReadMaxBytes(t *testing.T) {
 	readMaxBytes := 1024
 	mux.Handle(pingv1connect.NewPingServiceHandler(
 		pingServer{},
-		connect.WithReadMaxBytes(readMaxBytes),
+		connect.WithHandlerOptional(func(spec connect.Spec) connect.HandlerOption {
+			if spec.Procedure == pingv1connect.PingServicePingProcedure {
+				return connect.WithReadMaxBytes(readMaxBytes)
+			}
+			return nil
+		}),
 	))
 	readMaxBytesMatrix := func(t *testing.T, client pingv1connect.PingServiceClient, compressed bool) {
 		t.Helper()

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -1001,11 +1001,12 @@ func TestHandlerWithReadMaxBytes(t *testing.T) {
 	readMaxBytes := 1024
 	mux.Handle(pingv1connect.NewPingServiceHandler(
 		pingServer{},
-		connect.WithHandlerOptional(func(spec connect.Spec) connect.HandlerOption {
+		connect.WithConditionalHandlerOptions(func(spec connect.Spec) []connect.HandlerOption {
+			var options []connect.HandlerOption
 			if spec.Procedure == pingv1connect.PingServicePingProcedure {
-				return connect.WithReadMaxBytes(readMaxBytes)
+				options = append(options, connect.WithReadMaxBytes(readMaxBytes))
 			}
-			return nil
+			return options
 		}),
 	))
 	readMaxBytesMatrix := func(t *testing.T, client pingv1connect.PingServiceClient, compressed bool) {

--- a/error_writer.go
+++ b/error_writer.go
@@ -40,8 +40,9 @@ type ErrorWriter struct {
 // NewErrorWriter constructs an ErrorWriter. To properly recognize supported
 // RPC Content-Types in net/http middleware, you must pass the same
 // HandlerOptions to NewErrorWriter and any wrapped Connect handlers.
+// Conditional options are ignored.
 func NewErrorWriter(opts ...HandlerOption) *ErrorWriter {
-	config := newHandlerConfig("", ^StreamType(0), opts)
+	config := newHandlerConfig("", StreamTypeUnary, opts)
 	writer := &ErrorWriter{
 		bufferPool:                   config.BufferPool,
 		protobuf:                     newReadOnlyCodecs(config.Codecs).Protobuf(),

--- a/error_writer.go
+++ b/error_writer.go
@@ -41,7 +41,7 @@ type ErrorWriter struct {
 // RPC Content-Types in net/http middleware, you must pass the same
 // HandlerOptions to NewErrorWriter and any wrapped Connect handlers.
 func NewErrorWriter(opts ...HandlerOption) *ErrorWriter {
-	config := newHandlerConfig("", opts)
+	config := newHandlerConfig("", ^StreamType(0), opts)
 	writer := &ErrorWriter{
 		bufferPool:                   config.BufferPool,
 		protobuf:                     newReadOnlyCodecs(config.Codecs).Protobuf(),

--- a/error_writer.go
+++ b/error_writer.go
@@ -40,7 +40,7 @@ type ErrorWriter struct {
 // NewErrorWriter constructs an ErrorWriter. To properly recognize supported
 // RPC Content-Types in net/http middleware, you must pass the same
 // HandlerOptions to NewErrorWriter and any wrapped Connect handlers.
-// Conditional options are ignored.
+// Options supplied via [WithConditionalHandlerOptions] are ignored.
 func NewErrorWriter(opts ...HandlerOption) *ErrorWriter {
 	config := newHandlerConfig("", StreamTypeUnary, opts)
 	writer := &ErrorWriter{

--- a/interceptor_example_test.go
+++ b/interceptor_example_test.go
@@ -95,3 +95,14 @@ func ExampleWithInterceptors() {
 	// inner interceptor: after call
 	// outer interceptor: after call
 }
+
+func ExampleWithConditionalHandlerOptions() {
+	connect.WithConditionalHandlerOptions(func(spec connect.Spec) []connect.HandlerOption {
+		var options []connect.HandlerOption
+		if spec.Procedure == pingv1connect.PingServicePingProcedure {
+			options = append(options, connect.WithReadMaxBytes(1024))
+		}
+		return options
+	})
+	// Output:
+}

--- a/option.go
+++ b/option.go
@@ -166,32 +166,10 @@ func WithRequireConnectProtocolHeader() HandlerOption {
 	return &requireConnectProtocolHeaderOption{}
 }
 
-// WithConditionalHandlerOptions is a function that returns a HandlerOption.
+// WithConditionalHandlerOptions accepts a function that returns a HandlerOption.
 // It's used to conditionally apply HandlerOption to a Handler based on the Spec.
-// For example, to apply a HandlerOption only to a specific procedure:
-//
-//	connect.WithConditionalHandlerOptions(func(spec connect.Spec) (options []connect.HandlerOption) {
-//		if spec.Procedure == pingv1connect.PingServicePingProcedure {
-//			options = append(options, connect.WithReadMaxBytes(1024))
-//		}
-//		return options
-//	})
 func WithConditionalHandlerOptions(conditional func(spec Spec) []HandlerOption) HandlerOption {
 	return &conditionalHandlerOptions{conditional: conditional}
-}
-
-type conditionalHandlerOptions struct {
-	conditional func(spec Spec) []HandlerOption
-}
-
-func (o *conditionalHandlerOptions) applyToHandler(config *handlerConfig) {
-	spec := config.newSpec()
-	if spec.Procedure == "" {
-		return // ignore empty specs
-	}
-	for _, option := range o.conditional(spec) {
-		option.applyToHandler(config)
-	}
 }
 
 // Option implements both [ClientOption] and [HandlerOption], so it can be
@@ -584,4 +562,18 @@ func withProtoJSONCodecs() HandlerOption {
 		WithCodec(&protoJSONCodec{codecNameJSON}),
 		WithCodec(&protoJSONCodec{codecNameJSONCharsetUTF8}),
 	)
+}
+
+type conditionalHandlerOptions struct {
+	conditional func(spec Spec) []HandlerOption
+}
+
+func (o *conditionalHandlerOptions) applyToHandler(config *handlerConfig) {
+	spec := config.newSpec()
+	if spec.Procedure == "" {
+		return // ignore empty specs
+	}
+	for _, option := range o.conditional(spec) {
+		option.applyToHandler(config)
+	}
 }

--- a/option.go
+++ b/option.go
@@ -166,22 +166,31 @@ func WithRequireConnectProtocolHeader() HandlerOption {
 	return &requireConnectProtocolHeaderOption{}
 }
 
-// WithHandlerOptional is a function that returns a HandlerOption. It's used
-// to conditionally apply HandlerOption to a Handler based on the Spec.
+// WithConditionalHandlerOptions is a function that returns a HandlerOption.
+// It's used to conditionally apply HandlerOption to a Handler based on the Spec.
 // For example, to apply a HandlerOption only to a specific procedure:
 //
-//	connect.WithHandlerOptional(func(spec connect.Spec) connect.HandlerOption {
+//	connect.WithConditionalHandlerOptions(func(spec connect.Spec) (options []connect.HandlerOption) {
 //		if spec.Procedure == pingv1connect.PingServicePingProcedure {
-//			return connect.WithReadMaxBytes(1024)
+//			options = append(options, connect.WithReadMaxBytes(1024))
 //		}
-//		return nil
+//		return options
 //	})
-type WithHandlerOptional func(Spec) HandlerOption
+func WithConditionalHandlerOptions(conditional func(spec Spec) []HandlerOption) HandlerOption {
+	return &conditionalHandlerOptions{conditional: conditional}
+}
 
-func (f WithHandlerOptional) applyToHandler(h *handlerConfig) {
-	spec := h.newSpec()
-	if option := f(spec); option != nil {
-		option.applyToHandler(h)
+type conditionalHandlerOptions struct {
+	conditional func(spec Spec) []HandlerOption
+}
+
+func (o *conditionalHandlerOptions) applyToHandler(config *handlerConfig) {
+	spec := config.newSpec()
+	if spec.Procedure == "" {
+		return // ignore empty specs
+	}
+	for _, option := range o.conditional(spec) {
+		option.applyToHandler(config)
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -166,6 +166,25 @@ func WithRequireConnectProtocolHeader() HandlerOption {
 	return &requireConnectProtocolHeaderOption{}
 }
 
+// WithHandlerOptional is a function that returns a HandlerOption. It's used
+// to conditionally apply HandlerOption to a Handler based on the Spec.
+// For example, to apply a HandlerOption only to a specific procedure:
+//
+//	connect.WithHandlerOptional(func(spec connect.Spec) connect.HandlerOption {
+//		if spec.Procedure == pingv1connect.PingServicePingProcedure {
+//			return connect.WithReadMaxBytes(1024)
+//		}
+//		return nil
+//	})
+type WithHandlerOptional func(Spec) HandlerOption
+
+func (f WithHandlerOptional) applyToHandler(h *handlerConfig) {
+	spec := h.newSpec()
+	if option := f(spec); option != nil {
+		option.applyToHandler(h)
+	}
+}
+
 // Option implements both [ClientOption] and [HandlerOption], so it can be
 // applied both client-side and server-side.
 type Option interface {


### PR DESCRIPTION
Allows servers to set specific configuration based on the methods Spec.
This can be used to configure a specific route with different limits, such as:

```go
connect.WithConditionalHandlerOptions(func(spec connect.Spec) (options []connect.HandlerOption) {
	if spec.Procedure == pingv1connect.PingServicePingProcedure {
		options = append(options, connect.WithReadMaxBytes(1024))
	}
	return options
})
```
