### PR TITLE
Surface io.EOF errors as io.ErrUnexpectedEOF for gRPC

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -704,7 +704,7 @@ func TestGRPCMissingTrailersError(t *testing.T) {
 		var connectErr *connect.Error
 		ok := errors.As(err, &connectErr)
 		assert.True(t, ok)
-		assert.Equal(t, connectErr.Code(), connect.CodeInternal)
+		assert.Equal(t, connectErr.Code(), connect.CodeUnknown)
 		assert.True(
 			t,
 			strings.HasSuffix(connectErr.Message(), "protocol error: no Grpc-Status trailer"),
@@ -2129,8 +2129,8 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			_, _ = responseWriter.Write(head[:])
 			_, _ = responseWriter.Write(payload)
 		},
-		expectCode: connect.CodeInternal,
-		expectMsg:  "internal: protocol error: no Grpc-Status trailer",
+		expectCode: connect.CodeUnknown,
+		expectMsg:  "unknown: protocol error: no Grpc-Status trailer",
 	}, {
 		name:    "grpc-web_missing_end",
 		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPCWeb()},
@@ -2140,8 +2140,8 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			_, _ = responseWriter.Write(head[:])
 			_, _ = responseWriter.Write(payload)
 		},
-		expectCode: connect.CodeInternal,
-		expectMsg:  "internal: protocol error: no Grpc-Status trailer",
+		expectCode: connect.CodeUnknown,
+		expectMsg:  "unknown: protocol error: no Grpc-Status trailer",
 	}, {
 		name:    "connect_partial_payload",
 		options: []connect.ClientOption{connect.WithProtoJSON()},

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -704,10 +704,10 @@ func TestGRPCMissingTrailersError(t *testing.T) {
 		var connectErr *connect.Error
 		ok := errors.As(err, &connectErr)
 		assert.True(t, ok)
-		assert.Equal(t, connectErr.Code(), connect.CodeUnknown)
+		assert.Equal(t, connectErr.Code(), connect.CodeInternal)
 		assert.True(
 			t,
-			strings.HasSuffix(connectErr.Message(), "protocol error: no Grpc-Status trailer"),
+			strings.HasSuffix(connectErr.Message(), "protocol error: no Grpc-Status trailer: unexpected EOF"),
 		)
 	}
 
@@ -2118,8 +2118,8 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			_, _ = responseWriter.Write(head[:])
 			_, _ = responseWriter.Write(payload)
 		},
-		expectCode: connect.CodeUnknown,
-		expectMsg:  "unknown: unexpected EOF",
+		expectCode: connect.CodeInternal,
+		expectMsg:  "internal: protocol error: unexpected EOF",
 	}, {
 		name:    "grpc_missing_end",
 		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPC()},
@@ -2129,8 +2129,8 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			_, _ = responseWriter.Write(head[:])
 			_, _ = responseWriter.Write(payload)
 		},
-		expectCode: connect.CodeUnknown,
-		expectMsg:  "unknown: protocol error: no Grpc-Status trailer",
+		expectCode: connect.CodeInternal,
+		expectMsg:  "internal: protocol error: no Grpc-Status trailer: unexpected EOF",
 	}, {
 		name:    "grpc-web_missing_end",
 		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPCWeb()},
@@ -2140,8 +2140,8 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			_, _ = responseWriter.Write(head[:])
 			_, _ = responseWriter.Write(payload)
 		},
-		expectCode: connect.CodeUnknown,
-		expectMsg:  "unknown: protocol error: no Grpc-Status trailer",
+		expectCode: connect.CodeInternal,
+		expectMsg:  "internal: protocol error: no Grpc-Status trailer: unexpected EOF",
 	}, {
 		name:    "connect_partial_payload",
 		options: []connect.ClientOption{connect.WithProtoJSON()},

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2093,8 +2093,6 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			return
 		}
 		_, _ = io.Copy(io.Discard, request.Body)
-		header := responseWriter.Header()
-		header.Set("Content-Type", "application/connect+json")
 		testcase(responseWriter, request)
 	})
 	server := httptest.NewUnstartedServer(mux)
@@ -2102,38 +2100,107 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 	server.StartTLS()
 	t.Cleanup(server.Close)
 
-	client := pingv1connect.NewPingServiceClient(
-		server.Client(),
-		server.URL,
-		connect.WithProtoJSON(),
-	)
 	head := [5]byte{}
 	payload := []byte(`{"number": 42}`)
 	binary.BigEndian.PutUint32(head[1:], uint32(len(payload)))
 	testcases := []struct {
 		name       string
 		handler    http.HandlerFunc
+		options    []connect.ClientOption
 		expectCode connect.Code
 		expectMsg  string
 	}{{
-		name: "stream_unexpected_eof",
-		handler: func(responseWriter http.ResponseWriter, request *http.Request) {
+		name:    "connect_missing_end",
+		options: []connect.ClientOption{connect.WithProtoJSON()},
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			header := responseWriter.Header()
+			header.Set("Content-Type", "application/connect+json")
 			_, _ = responseWriter.Write(head[:])
 			_, _ = responseWriter.Write(payload)
 		},
 		expectCode: connect.CodeUnknown,
 		expectMsg:  "unknown: unexpected EOF",
 	}, {
-		name: "stream_partial_payload",
-		handler: func(responseWriter http.ResponseWriter, request *http.Request) {
+		name:    "grpc_missing_end",
+		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPC()},
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			header := responseWriter.Header()
+			header.Set("Content-Type", "application/grpc+json")
+			_, _ = responseWriter.Write(head[:])
+			_, _ = responseWriter.Write(payload)
+		},
+		expectCode: connect.CodeInternal,
+		expectMsg:  "internal: gRPC protocol error: no Grpc-Status trailer",
+	}, {
+		name:    "grpc-web_missing_end",
+		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPCWeb()},
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			header := responseWriter.Header()
+			header.Set("Content-Type", "application/grpc-web+json")
+			_, _ = responseWriter.Write(head[:])
+			_, _ = responseWriter.Write(payload)
+		},
+		expectCode: connect.CodeInternal,
+		expectMsg:  "internal: gRPC protocol error: no Grpc-Status trailer",
+	}, {
+		name:    "connect_partial_payload",
+		options: []connect.ClientOption{connect.WithProtoJSON()},
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			header := responseWriter.Header()
+			header.Set("Content-Type", "application/connect+json")
 			_, _ = responseWriter.Write(head[:])
 			_, _ = responseWriter.Write(payload[:len(payload)-1])
 		},
 		expectCode: connect.CodeInvalidArgument,
 		expectMsg:  fmt.Sprintf("invalid_argument: protocol error: promised %d bytes in enveloped message, got %d bytes", len(payload), len(payload)-1),
 	}, {
-		name: "stream_partial_frame",
-		handler: func(responseWriter http.ResponseWriter, request *http.Request) {
+		name:    "grpc_partial_payload",
+		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPC()},
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			header := responseWriter.Header()
+			header.Set("Content-Type", "application/grpc+json")
+			_, _ = responseWriter.Write(head[:])
+			_, _ = responseWriter.Write(payload[:len(payload)-1])
+		},
+		expectCode: connect.CodeInvalidArgument,
+		expectMsg:  fmt.Sprintf("invalid_argument: protocol error: promised %d bytes in enveloped message, got %d bytes", len(payload), len(payload)-1),
+	}, {
+		name:    "grpc-web_partial_payload",
+		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPCWeb()},
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			header := responseWriter.Header()
+			header.Set("Content-Type", "application/grpc-web+json")
+			_, _ = responseWriter.Write(head[:])
+			_, _ = responseWriter.Write(payload[:len(payload)-1])
+		},
+		expectCode: connect.CodeInvalidArgument,
+		expectMsg:  fmt.Sprintf("invalid_argument: protocol error: promised %d bytes in enveloped message, got %d bytes", len(payload), len(payload)-1),
+	}, {
+		name:    "connect_partial_frame",
+		options: []connect.ClientOption{connect.WithProtoJSON()},
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			header := responseWriter.Header()
+			header.Set("Content-Type", "application/connect+json")
+			_, _ = responseWriter.Write(head[:4])
+		},
+		expectCode: connect.CodeInvalidArgument,
+		expectMsg:  "invalid_argument: protocol error: incomplete envelope: unexpected EOF",
+	}, {
+		name:    "grpc_partial_frame",
+		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPC()},
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			header := responseWriter.Header()
+			header.Set("Content-Type", "application/grpc+json")
+			_, _ = responseWriter.Write(head[:4])
+		},
+		expectCode: connect.CodeInvalidArgument,
+		expectMsg:  "invalid_argument: protocol error: incomplete envelope: unexpected EOF",
+	}, {
+		name:    "grpc-web_partial_frame",
+		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPCWeb()},
+		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			header := responseWriter.Header()
+			header.Set("Content-Type", "application/grpc-web+json")
 			_, _ = responseWriter.Write(head[:4])
 		},
 		expectCode: connect.CodeInvalidArgument,
@@ -2146,6 +2213,11 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
+			client := pingv1connect.NewPingServiceClient(
+				server.Client(),
+				server.URL,
+				testcase.options...,
+			)
 			const upTo = 2
 			request := connect.NewRequest(&pingv1.CountUpRequest{Number: upTo})
 			request.Header().Set("Test-Case", t.Name())
@@ -2155,8 +2227,8 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 				assert.Equal(t, stream.Msg().Number, 42)
 			}
 			assert.NotNil(t, stream.Err())
-			assert.Equal(t, connect.CodeOf(stream.Err()), testcase.expectCode)
 			t.Log(stream.Err())
+			assert.Equal(t, connect.CodeOf(stream.Err()), testcase.expectCode)
 			assert.Equal(t, stream.Err().Error(), testcase.expectMsg)
 		})
 	}

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -707,7 +707,7 @@ func TestGRPCMissingTrailersError(t *testing.T) {
 		assert.Equal(t, connectErr.Code(), connect.CodeInternal)
 		assert.True(
 			t,
-			strings.HasSuffix(connectErr.Message(), "gRPC protocol error: no Grpc-Status trailer"),
+			strings.HasSuffix(connectErr.Message(), "protocol error: no Grpc-Status trailer"),
 		)
 	}
 
@@ -2130,7 +2130,7 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			_, _ = responseWriter.Write(payload)
 		},
 		expectCode: connect.CodeInternal,
-		expectMsg:  "internal: gRPC protocol error: no Grpc-Status trailer",
+		expectMsg:  "internal: protocol error: no Grpc-Status trailer",
 	}, {
 		name:    "grpc-web_missing_end",
 		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPCWeb()},
@@ -2141,7 +2141,7 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			_, _ = responseWriter.Write(payload)
 		},
 		expectCode: connect.CodeInternal,
-		expectMsg:  "internal: gRPC protocol error: no Grpc-Status trailer",
+		expectMsg:  "internal: protocol error: no Grpc-Status trailer",
 	}, {
 		name:    "connect_partial_payload",
 		options: []connect.ClientOption{connect.WithProtoJSON()},

--- a/envelope.go
+++ b/envelope.go
@@ -187,7 +187,7 @@ func (r *envelopeReader) Unmarshal(message any) *Error {
 		if r.compressionPool == nil {
 			return errorf(
 				CodeInvalidArgument,
-				"gRPC protocol error: sent compressed message without Grpc-Encoding header",
+				"protocol error: sent compressed message without Grpc-Encoding header",
 			)
 		}
 		decompressed := r.bufferPool.Get()

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -609,7 +609,7 @@ func (cc *connectStreamingClientConn) Receive(msg any) error {
 	// If the error is EOF but not from a last message, we want to return
 	// io.ErrUnexpectedEOF instead.
 	if errors.Is(err, io.EOF) && !errors.Is(err, errSpecialEnvelope) {
-		err = NewError(CodeUnknown, io.ErrUnexpectedEOF)
+		err = errorf(CodeInternal, "protocol error: %w", io.ErrUnexpectedEOF)
 	}
 	// There's no error in the trailers, so this was probably an error
 	// converting the bytes to a message, an error reading from the network, or

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -67,7 +67,7 @@ var (
 	grpcAllowedMethods    = map[string]struct{}{
 		http.MethodPost: {},
 	}
-	errTrailersWithoutGRPCStatus = fmt.Errorf("gRPC protocol error: no %s trailer", grpcHeaderStatus)
+	errTrailersWithoutGRPCStatus = fmt.Errorf("protocol error: no %s trailer", grpcHeaderStatus)
 
 	// defaultGrpcUserAgent follows
 	// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#user-agents:
@@ -737,7 +737,7 @@ func grpcErrorFromTrailer(protobuf Codec, trailer http.Header) *Error {
 
 	code, err := strconv.ParseUint(codeHeader, 10 /* base */, 32 /* bitsize */)
 	if err != nil {
-		return errorf(CodeInternal, "gRPC protocol error: invalid error code %q", codeHeader)
+		return errorf(CodeInternal, "protocol error: invalid error code %q", codeHeader)
 	}
 	message := grpcPercentDecode(getHeaderCanonical(trailer, grpcHeaderMessage))
 	retErr := NewWireError(Code(code), errors.New(message))
@@ -769,14 +769,14 @@ func grpcParseTimeout(timeout string) (time.Duration, error) {
 	}
 	unit, ok := grpcTimeoutUnitLookup[timeout[len(timeout)-1]]
 	if !ok {
-		return 0, fmt.Errorf("gRPC protocol error: timeout %q has invalid unit", timeout)
+		return 0, fmt.Errorf("protocol error: timeout %q has invalid unit", timeout)
 	}
 	num, err := strconv.ParseInt(timeout[:len(timeout)-1], 10 /* base */, 64 /* bitsize */)
 	if err != nil || num < 0 {
-		return 0, fmt.Errorf("gRPC protocol error: invalid timeout %q", timeout)
+		return 0, fmt.Errorf("protocol error: invalid timeout %q", timeout)
 	}
 	if num > 99999999 { // timeout must be ASCII string of at most 8 digits
-		return 0, fmt.Errorf("gRPC protocol error: timeout %q is too long", timeout)
+		return 0, fmt.Errorf("protocol error: timeout %q is too long", timeout)
 	}
 	if unit == time.Hour && num > grpcTimeoutMaxHours {
 		// Timeout is effectively unbounded, so ignore it. The grpc-go

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -67,7 +67,7 @@ var (
 	grpcAllowedMethods    = map[string]struct{}{
 		http.MethodPost: {},
 	}
-	errTrailersWithoutGRPCStatus = fmt.Errorf("protocol error: no %s trailer", grpcHeaderStatus)
+	errTrailersWithoutGRPCStatus = fmt.Errorf("protocol error: no %s trailer: %w", grpcHeaderStatus, io.ErrUnexpectedEOF)
 
 	// defaultGrpcUserAgent follows
 	// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#user-agents:
@@ -729,7 +729,7 @@ func grpcHTTPToCode(httpCode int) Code {
 func grpcErrorFromTrailer(protobuf Codec, trailer http.Header) *Error {
 	codeHeader := getHeaderCanonical(trailer, grpcHeaderStatus)
 	if codeHeader == "" {
-		return NewError(CodeUnknown, errTrailersWithoutGRPCStatus)
+		return NewError(CodeInternal, errTrailersWithoutGRPCStatus)
 	}
 	if codeHeader == "0" {
 		return nil

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -729,7 +729,7 @@ func grpcHTTPToCode(httpCode int) Code {
 func grpcErrorFromTrailer(protobuf Codec, trailer http.Header) *Error {
 	codeHeader := getHeaderCanonical(trailer, grpcHeaderStatus)
 	if codeHeader == "" {
-		return NewError(CodeInternal, errTrailersWithoutGRPCStatus)
+		return NewError(CodeUnknown, errTrailersWithoutGRPCStatus)
 	}
 	if codeHeader == "0" {
 		return nil


### PR DESCRIPTION
Cover the gRPC and gRPC-Web protocols in the tests for `io.ErrUnexpectedEOF`, and ensure that error codes and observable `errors.Is` behavior is consistent for all 3 supported RPC protocols.