### PR TITLE
[WIP] Adds types for request and response of connect methods

### DIFF
--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -241,8 +241,9 @@ func generateServiceTypeAliases(g *protogen.GeneratedFile, services []*protogen.
 						", "+g.QualifiedGoIdent(method.Output.GoIdent)+"]")
 			} else if isStreamingClient {
 				g.P(typeNames.ClientRequest, " = ",
-					g.QualifiedGoIdent(connectPackage.Ident("Request"))+
-						"["+g.QualifiedGoIdent(method.Input.GoIdent)+"]")
+					g.QualifiedGoIdent(connectPackage.Ident("ClientStreamForClient"))+
+						"["+g.QualifiedGoIdent(method.Input.GoIdent)+
+						", "+g.QualifiedGoIdent(method.Output.GoIdent)+"]")
 				g.P(typeNames.HandlerRequest, " = ",
 					g.QualifiedGoIdent(connectPackage.Ident("ClientStream"))+
 						"["+g.QualifiedGoIdent(method.Input.GoIdent)+"]")

--- a/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
+++ b/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
@@ -51,9 +51,15 @@ const (
 	CollideServiceImportProcedure = "/connect.collide.v1.CollideService/Import"
 )
 
+type (
+	// Import
+	CollideServiceImportRequest  = connect_go.Request[v1.ImportRequest]
+	CollideServiceImportResponse = connect_go.Response[v1.ImportResponse]
+)
+
 // CollideServiceClient is a client for the connect.collide.v1.CollideService service.
 type CollideServiceClient interface {
-	Import(context.Context, *connect_go.Request[v1.ImportRequest]) (*connect_go.Response[v1.ImportResponse], error)
+	Import(context.Context, *CollideServiceImportRequest) (*CollideServiceImportResponse, error)
 }
 
 // NewCollideServiceClient constructs a client for the connect.collide.v1.CollideService service. By
@@ -80,13 +86,13 @@ type collideServiceClient struct {
 }
 
 // Import calls connect.collide.v1.CollideService.Import.
-func (c *collideServiceClient) Import(ctx context.Context, req *connect_go.Request[v1.ImportRequest]) (*connect_go.Response[v1.ImportResponse], error) {
+func (c *collideServiceClient) Import(ctx context.Context, req *CollideServiceImportRequest) (*CollideServiceImportResponse, error) {
 	return c._import.CallUnary(ctx, req)
 }
 
 // CollideServiceHandler is an implementation of the connect.collide.v1.CollideService service.
 type CollideServiceHandler interface {
-	Import(context.Context, *connect_go.Request[v1.ImportRequest]) (*connect_go.Response[v1.ImportResponse], error)
+	Import(context.Context, *CollideServiceImportRequest) (*CollideServiceImportResponse, error)
 }
 
 // NewCollideServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -113,6 +119,6 @@ func NewCollideServiceHandler(svc CollideServiceHandler, opts ...connect_go.Hand
 // UnimplementedCollideServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedCollideServiceHandler struct{}
 
-func (UnimplementedCollideServiceHandler) Import(context.Context, *connect_go.Request[v1.ImportRequest]) (*connect_go.Response[v1.ImportResponse], error) {
+func (UnimplementedCollideServiceHandler) Import(context.Context, *CollideServiceImportRequest) (*CollideServiceImportResponse, error) {
 	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.collide.v1.CollideService.Import is not implemented"))
 }

--- a/internal/gen/connect/import/v1/importv1connect/import.connect.go
+++ b/internal/gen/connect/import/v1/importv1connect/import.connect.go
@@ -37,6 +37,8 @@ const (
 	ImportServiceName = "connect.import.v1.ImportService"
 )
 
+type ()
+
 // ImportServiceClient is a client for the connect.import.v1.ImportService service.
 type ImportServiceClient interface {
 }

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -72,7 +72,7 @@ type (
 	PingServiceFailRequest  = connect_go.Request[v1.FailRequest]
 	PingServiceFailResponse = connect_go.Response[v1.FailResponse]
 	// Sum
-	PingServiceSumClientStream = connect_go.Request[v1.SumRequest]
+	PingServiceSumClientStream = connect_go.ClientStreamForClient[v1.SumRequest, v1.SumResponse]
 	PingServiceSumStream       = connect_go.ClientStream[v1.SumRequest]
 	PingServiceSumResponse     = connect_go.Response[v1.SumResponse]
 	// CountUp

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -64,18 +64,38 @@ const (
 	PingServiceCumSumProcedure = "/connect.ping.v1.PingService/CumSum"
 )
 
+type (
+	// Ping
+	PingServicePingRequest  = connect_go.Request[v1.PingRequest]
+	PingServicePingResponse = connect_go.Response[v1.PingResponse]
+	// Fail
+	PingServiceFailRequest  = connect_go.Request[v1.FailRequest]
+	PingServiceFailResponse = connect_go.Response[v1.FailResponse]
+	// Sum
+	PingServiceSumClientStream = connect_go.Request[v1.SumRequest]
+	PingServiceSumStream       = connect_go.ClientStream[v1.SumRequest]
+	PingServiceSumResponse     = connect_go.Response[v1.SumResponse]
+	// CountUp
+	PingServiceCountUpRequest      = connect_go.Request[v1.CountUpRequest]
+	PingServiceCountUpClientStream = connect_go.ServerStreamForClient[v1.CountUpResponse]
+	PingServiceCountUpStream       = connect_go.ServerStream[v1.CountUpResponse]
+	// CumSum
+	PingServiceCumSumClientStream = connect_go.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse]
+	PingServiceCumSumStream       = connect_go.BidiStream[v1.CumSumRequest, v1.CumSumResponse]
+)
+
 // PingServiceClient is a client for the connect.ping.v1.PingService service.
 type PingServiceClient interface {
 	// Ping sends a ping to the server to determine if it's reachable.
-	Ping(context.Context, *connect_go.Request[v1.PingRequest]) (*connect_go.Response[v1.PingResponse], error)
+	Ping(context.Context, *PingServicePingRequest) (*PingServicePingResponse, error)
 	// Fail always fails.
-	Fail(context.Context, *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error)
+	Fail(context.Context, *PingServiceFailRequest) (*PingServiceFailResponse, error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context) *connect_go.ClientStreamForClient[v1.SumRequest, v1.SumResponse]
+	Sum(context.Context) *PingServiceSumClientStream
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect_go.Request[v1.CountUpRequest]) (*connect_go.ServerStreamForClient[v1.CountUpResponse], error)
+	CountUp(context.Context, *PingServiceCountUpRequest) (*PingServiceCountUpClientStream, error)
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
-	CumSum(context.Context) *connect_go.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse]
+	CumSum(context.Context) *PingServiceCumSumClientStream
 }
 
 // NewPingServiceClient constructs a client for the connect.ping.v1.PingService service. By default,
@@ -127,42 +147,42 @@ type pingServiceClient struct {
 }
 
 // Ping calls connect.ping.v1.PingService.Ping.
-func (c *pingServiceClient) Ping(ctx context.Context, req *connect_go.Request[v1.PingRequest]) (*connect_go.Response[v1.PingResponse], error) {
+func (c *pingServiceClient) Ping(ctx context.Context, req *PingServicePingRequest) (*PingServicePingResponse, error) {
 	return c.ping.CallUnary(ctx, req)
 }
 
 // Fail calls connect.ping.v1.PingService.Fail.
-func (c *pingServiceClient) Fail(ctx context.Context, req *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error) {
+func (c *pingServiceClient) Fail(ctx context.Context, req *PingServiceFailRequest) (*PingServiceFailResponse, error) {
 	return c.fail.CallUnary(ctx, req)
 }
 
 // Sum calls connect.ping.v1.PingService.Sum.
-func (c *pingServiceClient) Sum(ctx context.Context) *connect_go.ClientStreamForClient[v1.SumRequest, v1.SumResponse] {
+func (c *pingServiceClient) Sum(ctx context.Context) *PingServiceSumClientStream {
 	return c.sum.CallClientStream(ctx)
 }
 
 // CountUp calls connect.ping.v1.PingService.CountUp.
-func (c *pingServiceClient) CountUp(ctx context.Context, req *connect_go.Request[v1.CountUpRequest]) (*connect_go.ServerStreamForClient[v1.CountUpResponse], error) {
+func (c *pingServiceClient) CountUp(ctx context.Context, req *PingServiceCountUpRequest) (*PingServiceCountUpClientStream, error) {
 	return c.countUp.CallServerStream(ctx, req)
 }
 
 // CumSum calls connect.ping.v1.PingService.CumSum.
-func (c *pingServiceClient) CumSum(ctx context.Context) *connect_go.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse] {
+func (c *pingServiceClient) CumSum(ctx context.Context) *PingServiceCumSumClientStream {
 	return c.cumSum.CallBidiStream(ctx)
 }
 
 // PingServiceHandler is an implementation of the connect.ping.v1.PingService service.
 type PingServiceHandler interface {
 	// Ping sends a ping to the server to determine if it's reachable.
-	Ping(context.Context, *connect_go.Request[v1.PingRequest]) (*connect_go.Response[v1.PingResponse], error)
+	Ping(context.Context, *PingServicePingRequest) (*PingServicePingResponse, error)
 	// Fail always fails.
-	Fail(context.Context, *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error)
+	Fail(context.Context, *PingServiceFailRequest) (*PingServiceFailResponse, error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context, *connect_go.ClientStream[v1.SumRequest]) (*connect_go.Response[v1.SumResponse], error)
+	Sum(context.Context, *PingServiceSumStream) (*PingServiceSumResponse, error)
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect_go.Request[v1.CountUpRequest], *connect_go.ServerStream[v1.CountUpResponse]) error
+	CountUp(context.Context, *PingServiceCountUpRequest, *PingServiceCountUpStream) error
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
-	CumSum(context.Context, *connect_go.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error
+	CumSum(context.Context, *PingServiceCumSumStream) error
 }
 
 // NewPingServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -218,22 +238,22 @@ func NewPingServiceHandler(svc PingServiceHandler, opts ...connect_go.HandlerOpt
 // UnimplementedPingServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedPingServiceHandler struct{}
 
-func (UnimplementedPingServiceHandler) Ping(context.Context, *connect_go.Request[v1.PingRequest]) (*connect_go.Response[v1.PingResponse], error) {
+func (UnimplementedPingServiceHandler) Ping(context.Context, *PingServicePingRequest) (*PingServicePingResponse, error) {
 	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Ping is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) Fail(context.Context, *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error) {
+func (UnimplementedPingServiceHandler) Fail(context.Context, *PingServiceFailRequest) (*PingServiceFailResponse, error) {
 	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Fail is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) Sum(context.Context, *connect_go.ClientStream[v1.SumRequest]) (*connect_go.Response[v1.SumResponse], error) {
+func (UnimplementedPingServiceHandler) Sum(context.Context, *PingServiceSumStream) (*PingServiceSumResponse, error) {
 	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) CountUp(context.Context, *connect_go.Request[v1.CountUpRequest], *connect_go.ServerStream[v1.CountUpResponse]) error {
+func (UnimplementedPingServiceHandler) CountUp(context.Context, *PingServiceCountUpRequest, *PingServiceCountUpStream) error {
 	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CountUp is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) CumSum(context.Context, *connect_go.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error {
+func (UnimplementedPingServiceHandler) CumSum(context.Context, *PingServiceCumSumStream) error {
 	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CumSum is not implemented"))
 }


### PR DESCRIPTION
Concept to give types names based on the service and method names, the `input|ouput` type names aren't referred to.

`<Service><Method><"Request"|"Response"|"Stream"|"ClientStream">`

Possible solution for https://github.com/bufbuild/connect-go/issues/451