### PR TITLE
Separate Envelope writing from marshalling

### DIFF
--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -28,15 +28,7 @@ type bufferPool struct {
 	sync.Pool
 }
 
-func newBufferPool() *bufferPool {
-	return &bufferPool{
-		Pool: sync.Pool{
-			New: func() any {
-				return bytes.NewBuffer(make([]byte, 0, initialBufferSize))
-			},
-		},
-	}
-}
+func newBufferPool() *bufferPool { return &bufferPool{} }
 
 func (b *bufferPool) Get() *bytes.Buffer {
 	if buf, ok := b.Pool.Get().(*bytes.Buffer); ok {

--- a/connect.go
+++ b/connect.go
@@ -364,7 +364,7 @@ func receiveUnaryResponse[T any](conn StreamingClientConn) (*Response[T], error)
 	// In a well-formed stream, the response message may be followed by a block
 	// of in-stream trailers or HTTP trailers. To ensure that we receive the
 	// trailers, try to read another message from the stream.
-	if err := conn.Receive(new(T)); err == nil {
+	if err := conn.Receive(&msg); err == nil {
 		return nil, NewError(CodeUnknown, errors.New("unary stream has multiple messages"))
 	} else if err != nil && !errors.Is(err, io.EOF) {
 		return nil, NewError(CodeUnknown, err)

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2227,7 +2227,6 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 				assert.Equal(t, stream.Msg().Number, 42)
 			}
 			assert.NotNil(t, stream.Err())
-			t.Log(stream.Err())
 			assert.Equal(t, connect.CodeOf(stream.Err()), testcase.expectCode)
 			assert.Equal(t, stream.Err().Error(), testcase.expectMsg)
 		})

--- a/envelope.go
+++ b/envelope.go
@@ -19,269 +19,176 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 )
 
 // flagEnvelopeCompressed indicates that the data is compressed. It has the
 // same meaning in the gRPC-Web, gRPC-HTTP2, and Connect protocols.
 const flagEnvelopeCompressed = 0b00000001
 
-var errSpecialEnvelope = errorf(
-	CodeUnknown,
-	"final message has protocol-specific flags: %w",
-	// User code checks for end of stream with errors.Is(err, io.EOF).
-	io.EOF,
-)
-
-// envelope is a block of arbitrary bytes wrapped in gRPC and Connect's framing
-// protocol.
-//
-// Each message is preceded by a 5-byte prefix. The first byte is a uint8 used
-// as a set of bitwise flags, and the remainder is a uint32 indicating the
-// message length. gRPC and Connect interpret the bitwise flags differently, so
-// envelope leaves their interpretation up to the caller.
-type envelope struct {
-	Data  *bytes.Buffer
-	Flags uint8
+func newErrInvalidEnvelopeFlags(flags uint8) *Error {
+	return errorf(CodeInternal, "protocol error: invalid envelope flags %08b", flags)
 }
 
-func (e *envelope) IsSet(flag uint8) bool {
-	return e.Flags&flag == flag
-}
-
-type envelopeWriter struct {
-	writer           io.Writer
-	codec            Codec
-	compressMinBytes int
-	compressionPool  *compressionPool
-	bufferPool       *bufferPool
-	sendMaxBytes     int
-}
-
-func (w *envelopeWriter) Marshal(message any) *Error {
-	if message == nil {
-		if _, err := w.writer.Write(nil); err != nil {
-			if connectErr, ok := asError(err); ok {
-				return connectErr
-			}
-			return NewError(CodeUnknown, err)
-		}
-		return nil
-	}
-	if appender, ok := w.codec.(marshalAppender); ok {
-		return w.marshalAppend(message, appender)
-	}
-	return w.marshal(message)
-}
-
-// Write writes the enveloped message, compressing as necessary. It doesn't
-// retain any references to the supplied envelope or its underlying data.
-func (w *envelopeWriter) Write(env *envelope) *Error {
-	if env.IsSet(flagEnvelopeCompressed) ||
-		w.compressionPool == nil ||
-		env.Data.Len() < w.compressMinBytes {
-		if w.sendMaxBytes > 0 && env.Data.Len() > w.sendMaxBytes {
-			return errorf(CodeResourceExhausted, "message size %d exceeds sendMaxBytes %d", env.Data.Len(), w.sendMaxBytes)
-		}
-		return w.write(env)
-	}
-	data := w.bufferPool.Get()
-	defer w.bufferPool.Put(data)
-	if err := w.compressionPool.Compress(data, env.Data); err != nil {
-		return err
-	}
-	if w.sendMaxBytes > 0 && data.Len() > w.sendMaxBytes {
-		return errorf(CodeResourceExhausted, "compressed message size %d exceeds sendMaxBytes %d", data.Len(), w.sendMaxBytes)
-	}
-	return w.write(&envelope{
-		Data:  data,
-		Flags: env.Flags | flagEnvelopeCompressed,
-	})
-}
-
-func (w *envelopeWriter) marshalAppend(message any, codec marshalAppender) *Error {
-	// Codec supports MarshalAppend; try to re-use a []byte from the pool.
-	buffer := w.bufferPool.Get()
-	defer w.bufferPool.Put(buffer)
-	raw, err := codec.MarshalAppend(buffer.Bytes(), message)
-	if err != nil {
-		return errorf(CodeInternal, "marshal message: %w", err)
-	}
-	if cap(raw) > buffer.Cap() {
-		// The buffer from the pool was too small, so MarshalAppend grew the slice.
+// setBuffer sets the buffer to the given bytes. The buffer takes ownership of
+// the bytes, so the caller must not use the bytes after calling setBuffer.
+func setBuffer(dst *bytes.Buffer, buf []byte) {
+	if cap(buf) > dst.Cap() {
 		// Pessimistically assume that the too-small buffer is insufficient for the
 		// application workload, so there's no point in keeping it in the pool.
 		// Instead, replace it with the larger, newly-allocated slice. This
 		// allocates, but it's a small, constant-size allocation.
-		*buffer = *bytes.NewBuffer(raw)
+		*dst = *bytes.NewBuffer(buf)
 	} else {
-		// MarshalAppend didn't allocate, but we need to fix the internal state of
-		// the buffer. Compared to replacing the buffer (as above), buffer.Write
-		// copies but avoids allocating.
-		buffer.Write(raw)
+		// Write to the buffer large enough to hold the bytes.
+		dst.Write(buf)
 	}
-	envelope := &envelope{Data: buffer}
-	return w.Write(envelope)
 }
 
-func (w *envelopeWriter) marshal(message any) *Error {
+func marshal(dst *bytes.Buffer, message any, codec Codec) *Error {
+	if message == nil {
+		return nil
+	}
+	if codec, ok := codec.(marshalAppender); ok {
+		// Codec supports MarshalAppend; try to re-use a []byte from the pool.
+		raw, err := codec.MarshalAppend(dst.Bytes(), message)
+		if err != nil {
+			return errorf(CodeInternal, "marshal message: %w", err)
+		}
+		setBuffer(dst, raw)
+		return nil
+	}
 	// Codec doesn't support MarshalAppend; let Marshal allocate a []byte.
-	raw, err := w.codec.Marshal(message)
+	raw, err := codec.Marshal(message)
 	if err != nil {
 		return errorf(CodeInternal, "marshal message: %w", err)
 	}
-	buffer := bytes.NewBuffer(raw)
-	// Put our new []byte into the pool for later reuse.
-	defer w.bufferPool.Put(buffer)
-	envelope := &envelope{Data: buffer}
-	return w.Write(envelope)
-}
-
-func (w *envelopeWriter) write(env *envelope) *Error {
-	prefix := [5]byte{}
-	prefix[0] = env.Flags
-	binary.BigEndian.PutUint32(prefix[1:5], uint32(env.Data.Len()))
-	if _, err := w.writer.Write(prefix[:]); err != nil {
-		if connectErr, ok := asError(err); ok {
-			return connectErr
-		}
-		return errorf(CodeUnknown, "write envelope: %w", err)
-	}
-	if _, err := io.Copy(w.writer, env.Data); err != nil {
-		return errorf(CodeUnknown, "write message: %w", err)
-	}
+	setBuffer(dst, raw)
 	return nil
 }
 
-type envelopeReader struct {
-	reader          io.Reader
-	codec           Codec
-	last            envelope
-	compressionPool *compressionPool
-	bufferPool      *bufferPool
-	readMaxBytes    int
-}
-
-func (r *envelopeReader) Unmarshal(message any) *Error {
-	buffer := r.bufferPool.Get()
-	defer r.bufferPool.Put(buffer)
-
-	env := &envelope{Data: buffer}
-	err := r.Read(env)
-	switch {
-	case err == nil &&
-		(env.Flags == 0 || env.Flags == flagEnvelopeCompressed) &&
-		env.Data.Len() == 0:
-		// This is a standard message (because none of the top 7 bits are set) and
-		// there's no data, so the zero value of the message is correct.
-		return nil
-	case err != nil && errors.Is(err, io.EOF):
-		// The stream has ended. Propagate the EOF to the caller.
-		return err
-	case err != nil:
-		// Something's wrong.
-		return err
-	}
-
-	data := env.Data
-	if data.Len() > 0 && env.IsSet(flagEnvelopeCompressed) {
-		if r.compressionPool == nil {
-			return errorf(
-				CodeInvalidArgument,
-				"protocol error: sent compressed message without Grpc-Encoding header",
-			)
-		}
-		decompressed := r.bufferPool.Get()
-		defer r.bufferPool.Put(decompressed)
-		if err := r.compressionPool.Decompress(decompressed, data, int64(r.readMaxBytes)); err != nil {
-			return err
-		}
-		data = decompressed
-	}
-
-	if env.Flags != 0 && env.Flags != flagEnvelopeCompressed {
-		// One of the protocol-specific flags are set, so this is the end of the
-		// stream. Save the message for protocol-specific code to process and
-		// return a sentinel error. Since we've deferred functions to return env's
-		// underlying buffer to a pool, we need to keep a copy.
-		copiedData := make([]byte, data.Len())
-		copy(copiedData, data.Bytes())
-		r.last = envelope{
-			Data:  bytes.NewBuffer(copiedData),
-			Flags: env.Flags,
-		}
-		return errSpecialEnvelope
-	}
-
-	if err := r.codec.Unmarshal(data.Bytes(), message); err != nil {
+func unmarshal(src *bytes.Buffer, message any, codec Codec) *Error {
+	if err := codec.Unmarshal(src.Bytes(), message); err != nil {
 		return errorf(CodeInvalidArgument, "unmarshal into %T: %w", message, err)
 	}
 	return nil
 }
 
-func (r *envelopeReader) Read(env *envelope) *Error {
+func compress(buffer *bytes.Buffer, bufferPool *bufferPool, compressionPool *compressionPool) *Error {
+	data := bufferPool.Get()
+	defer bufferPool.Put(data)
+	if err := compressionPool.Compress(data, buffer); err != nil {
+		return err
+	}
+	buffer.Reset()
+	_, _ = data.WriteTo(buffer)
+	return nil
+}
+func decompress(buffer *bytes.Buffer, bufferPool *bufferPool, compressionPool *compressionPool, readMaxBytes int) *Error {
+	data := bufferPool.Get()
+	defer bufferPool.Put(data)
+	if err := compressionPool.Decompress(data, buffer, int64(readMaxBytes)); err != nil {
+		return err
+	}
+	buffer.Reset()
+	_, _ = data.WriteTo(buffer)
+	return nil
+}
+
+// func envelopeBuffer(flags uint8, src *bytes.Buffer) {
+// 	prefix := [5]byte{}
+// 	prefix[0] = flags
+// 	binary.BigEndian.PutUint32(prefix[1:5], uint32(src.Len()))
+// 	buf := append(src.Bytes(), prefix[:]...)
+// 	copy(buf[5:], buf[:5])
+// 	copy(buf[:5], prefix[:])
+// 	if cap(buf) > src.Cap() {
+// 		*src = *bytes.NewBuffer(buf)
+// 	} else {
+// 		src.Reset()
+// 		src.Write(buf)
+// 	}
+// }
+
+func writeEnvelope(dst io.Writer, flags uint8, src *bytes.Buffer) *Error {
+	prefix := [5]byte{}
+	prefix[0] = flags
+	binary.BigEndian.PutUint32(prefix[1:5], uint32(src.Len()))
+	if _, err := dst.Write(prefix[:]); err != nil {
+		if connectErr, ok := asError(err); ok {
+			return connectErr
+		}
+		return errorf(CodeUnknown, "write envelope: %w", err)
+	}
+	if _, err := src.WriteTo(dst); err != nil {
+		return errorf(CodeUnknown, "write message: %w", err)
+	}
+	return nil
+}
+
+func readEnvelope(dst *bytes.Buffer, src io.Reader, readMaxBytes int) (uint8, *Error) {
 	prefixes := [5]byte{}
-	prefixBytesRead, err := r.reader.Read(prefixes[:])
+	prefixBytesRead, err := src.Read(prefixes[:])
 
 	switch {
 	case (err == nil || errors.Is(err, io.EOF)) &&
 		prefixBytesRead == 5 &&
 		isSizeZeroPrefix(prefixes):
 		// Successfully read prefix and expect no additional data.
-		env.Flags = prefixes[0]
-		return nil
+		return prefixes[0], nil
 	case err != nil && errors.Is(err, io.EOF) && prefixBytesRead == 0:
 		// The stream ended cleanly. That's expected, but we need to propagate them
 		// to the user so that they know that the stream has ended. We shouldn't
 		// add any alarming text about protocol errors, though.
-		return NewError(CodeUnknown, err)
+		return 0, NewError(CodeUnknown, err)
 	case err != nil || prefixBytesRead < 5:
 		// Something else has gone wrong - the stream didn't end cleanly.
 		if connectErr, ok := asError(err); ok {
-			return connectErr
+			return 0, connectErr
 		}
 		if maxBytesErr := asMaxBytesError(err, "read 5 byte message prefix"); maxBytesErr != nil {
 			// We're reading from an http.MaxBytesHandler, and we've exceeded the read limit.
-			return maxBytesErr
+			return 0, maxBytesErr
 		}
 		if err == nil {
 			err = io.ErrUnexpectedEOF
 		}
-		return errorf(
+		return 0, errorf(
 			CodeInvalidArgument,
 			"protocol error: incomplete envelope: %w", err,
 		)
 	}
 	size := int(binary.BigEndian.Uint32(prefixes[1:5]))
 	if size < 0 {
-		return errorf(CodeInvalidArgument, "message size %d overflowed uint32", size)
+		return 0, errorf(CodeInvalidArgument, "message size %d overflowed uint32", size)
 	}
-	if r.readMaxBytes > 0 && size > r.readMaxBytes {
-		_, err := io.CopyN(io.Discard, r.reader, int64(size))
+	if readMaxBytes > 0 && size > readMaxBytes {
+		_, err := io.CopyN(io.Discard, src, int64(size))
 		if err != nil && !errors.Is(err, io.EOF) {
-			return errorf(CodeUnknown, "read enveloped message: %w", err)
+			return 0, errorf(CodeUnknown, "read enveloped message: %w", err)
 		}
-		return errorf(CodeResourceExhausted, "message size %d is larger than configured max %d", size, r.readMaxBytes)
+		return 0, errorf(CodeResourceExhausted, "message size %d is larger than configured max %d", size, readMaxBytes)
 	}
 	if size > 0 {
-		env.Data.Grow(size)
+		dst.Grow(size)
 		// At layer 7, we don't know exactly what's happening down in L4. Large
 		// length-prefixed messages may arrive in chunks, so we may need to read
 		// the request body past EOF. We also need to take care that we don't retry
 		// forever if the message is malformed.
 		remaining := int64(size)
 		for remaining > 0 {
-			bytesRead, err := io.CopyN(env.Data, r.reader, remaining)
+			bytesRead, err := io.CopyN(dst, src, remaining)
 			if err != nil && !errors.Is(err, io.EOF) {
 				if maxBytesErr := asMaxBytesError(err, "read %d byte message", size); maxBytesErr != nil {
 					// We're reading from an http.MaxBytesHandler, and we've exceeded the read limit.
-					return maxBytesErr
+					return 0, maxBytesErr
 				}
-				return errorf(CodeUnknown, "read enveloped message: %w", err)
+				return 0, errorf(CodeUnknown, "read enveloped message: %w", err)
 			}
 			if errors.Is(err, io.EOF) && bytesRead == 0 {
 				// We've gotten zero-length chunk of data. Message is likely malformed,
 				// don't wait for additional chunks.
-				return errorf(
+				return 0, errorf(
 					CodeInvalidArgument,
 					"protocol error: promised %d bytes in enveloped message, got %d bytes",
 					size,
@@ -291,15 +198,62 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 			remaining -= bytesRead
 		}
 	}
-	env.Flags = prefixes[0]
-	return nil
+	return prefixes[0], nil
 }
 
 func isSizeZeroPrefix(prefix [5]byte) bool {
-	for i := 1; i < 5; i++ {
-		if prefix[i] != 0 {
-			return false
-		}
+	return prefix[1]|prefix[2]|prefix[3]|prefix[4] == 0
+}
+
+func readAll(dst *bytes.Buffer, src io.Reader, readMaxBytes int) *Error {
+	limitReader := src
+	if readMaxBytes > 0 && int64(readMaxBytes) < math.MaxInt64 {
+		limitReader = io.LimitReader(src, int64(readMaxBytes)+1)
 	}
-	return true
+
+	// ReadFrom ignores io.EOF, so any error here is real.
+	bytesRead, err := dst.ReadFrom(limitReader)
+	if err != nil {
+		if connectErr, ok := asError(err); ok {
+			return connectErr
+		}
+		if readMaxBytesErr := asMaxBytesError(err, "read first %d bytes of message", bytesRead); readMaxBytesErr != nil {
+			return readMaxBytesErr
+		}
+		return errorf(CodeUnknown, "read message: %w", err)
+	}
+	if readMaxBytes > 0 && bytesRead > int64(readMaxBytes) {
+		// Attempt to read to end in order to allow connection re-use
+		discardedBytes, err := io.Copy(io.Discard, src)
+		if err != nil {
+			return errorf(CodeResourceExhausted,
+				"message is larger than configured max %d - unable to determine message size: %w",
+				readMaxBytes, err)
+		}
+		return errorf(CodeResourceExhausted,
+			"message size %d is larger than configured max %d",
+			bytesRead+discardedBytes, readMaxBytes)
+	}
+	return nil
+}
+
+func checkSendMaxBytes(buffer *bytes.Buffer, sendMaxBytes int, isCompressed bool) *Error {
+	if sendMaxBytes <= 0 || buffer.Len() <= sendMaxBytes {
+		return nil
+	}
+	tmpl := "message size %d exceeds sendMaxBytes %d"
+	if isCompressed {
+		tmpl = "compressed message size %d exceeds sendMaxBytes %d"
+	}
+	return errorf(CodeResourceExhausted, tmpl, buffer.Len(), sendMaxBytes)
+}
+
+func writeAll(dst io.Writer, src *bytes.Buffer) *Error {
+	if _, err := src.WriteTo(dst); err != nil {
+		if writeErr, ok := asError(err); ok {
+			return writeErr
+		}
+		return errorf(CodeUnknown, "write message: %w", err)
+	}
+	return nil
 }

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -586,7 +586,7 @@ func (cc *connectStreamingClientConn) Send(msg any) error {
 		}
 		flags |= flagEnvelopeCompressed
 	}
-	if err := checkSendMaxBytes(buffer, cc.sendMaxBytes, flags&flagEnvelopeCompressed > 0); err != nil {
+	if err := checkSendMaxBytes(buffer.Len(), cc.sendMaxBytes, flags&flagEnvelopeCompressed > 0); err != nil {
 		return err
 	}
 	if err := writeEnvelope(cc.duplexCall, flags, buffer); err != nil {
@@ -771,7 +771,7 @@ func (hc *connectUnaryHandlerConn) Send(msg any) error {
 		setHeaderCanonical(header, connectUnaryHeaderCompression, hc.compressionResponseName)
 		isCompressed = true
 	}
-	if err := checkSendMaxBytes(buffer, hc.sendMaxBytes, isCompressed); err != nil {
+	if err := checkSendMaxBytes(buffer.Len(), hc.sendMaxBytes, isCompressed); err != nil {
 		delHeaderCanonical(header, connectUnaryHeaderCompression)
 		return err
 	}
@@ -919,7 +919,7 @@ func (hc *connectStreamingHandlerConn) Send(msg any) error {
 		}
 		flags |= flagEnvelopeCompressed
 	}
-	if err := checkSendMaxBytes(buffer, hc.sendMaxBytes, flags&flagEnvelopeCompressed > 0); err != nil {
+	if err := checkSendMaxBytes(buffer.Len(), hc.sendMaxBytes, flags&flagEnvelopeCompressed > 0); err != nil {
 		return err
 	}
 	if err := writeEnvelope(hc.responseWriter, flags, buffer); err != nil {
@@ -983,7 +983,7 @@ func (cc *connectUnaryClientConn) sendMsg(buffer *bytes.Buffer, msg any) error {
 		setHeaderCanonical(header, connectUnaryHeaderCompression, cc.compressionName)
 		isCompressed = true
 	}
-	if err := checkSendMaxBytes(buffer, cc.sendMaxBytes, isCompressed); err != nil {
+	if err := checkSendMaxBytes(buffer.Len(), cc.sendMaxBytes, isCompressed); err != nil {
 		return err
 	}
 	if err := writeAll(cc.duplexCall, buffer); err != nil {
@@ -1004,7 +1004,7 @@ func (cc *connectUnaryClientConn) trySendGet(buffer *bytes.Buffer, msg any) erro
 		if err != nil {
 			return err
 		}
-		setBuffer(buffer, data)
+		buffer.Write(data)
 	}
 
 	isTooBig := cc.sendMaxBytes > 0 && buffer.Len() > cc.sendMaxBytes
@@ -1318,6 +1318,6 @@ func connectMarshalEndStreamMessage(dst *bytes.Buffer, end *connectEndStreamMess
 	if marshalErr != nil {
 		return errorf(CodeInternal, "marshal end stream: %w", marshalErr)
 	}
-	setBuffer(dst, data)
+	dst.Write(data)
 	return nil
 }

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -251,55 +250,37 @@ func (h *connectHandler) NewConn(
 	}
 	if h.Spec.StreamType == StreamTypeUnary {
 		conn = &connectUnaryHandlerConn{
-			spec:           h.Spec,
-			peer:           peer,
-			request:        request,
-			responseWriter: responseWriter,
-			marshaler: connectUnaryMarshaler{
-				writer:           responseWriter,
-				codec:            codec,
-				compressMinBytes: h.CompressMinBytes,
-				compressionName:  responseCompression,
-				compressionPool:  h.CompressionPools.Get(responseCompression),
-				bufferPool:       h.BufferPool,
-				header:           responseWriter.Header(),
-				sendMaxBytes:     h.SendMaxBytes,
-			},
-			unmarshaler: connectUnaryUnmarshaler{
-				reader:          requestBody,
-				codec:           codec,
-				compressionPool: h.CompressionPools.Get(requestCompression),
-				bufferPool:      h.BufferPool,
-				readMaxBytes:    h.ReadMaxBytes,
-			},
-			responseTrailer: make(http.Header),
+			spec:                    h.Spec,
+			peer:                    peer,
+			request:                 request,
+			requestBody:             requestBody,
+			responseWriter:          responseWriter,
+			responseTrailer:         make(http.Header),
+			codec:                   codec,
+			compressMinBytes:        h.CompressMinBytes,
+			compressionRequestName:  requestCompression,
+			compressionRequestPool:  h.CompressionPools.Get(requestCompression),
+			compressionResponseName: responseCompression,
+			compressionResponsePool: h.CompressionPools.Get(responseCompression),
+			bufferPool:              h.BufferPool,
+			sendMaxBytes:            h.SendMaxBytes,
+			readMaxBytes:            h.ReadMaxBytes,
 		}
 	} else {
 		conn = &connectStreamingHandlerConn{
-			spec:           h.Spec,
-			peer:           peer,
-			request:        request,
-			responseWriter: responseWriter,
-			marshaler: connectStreamingMarshaler{
-				envelopeWriter: envelopeWriter{
-					writer:           responseWriter,
-					codec:            codec,
-					compressMinBytes: h.CompressMinBytes,
-					compressionPool:  h.CompressionPools.Get(responseCompression),
-					bufferPool:       h.BufferPool,
-					sendMaxBytes:     h.SendMaxBytes,
-				},
-			},
-			unmarshaler: connectStreamingUnmarshaler{
-				envelopeReader: envelopeReader{
-					reader:          requestBody,
-					codec:           codec,
-					compressionPool: h.CompressionPools.Get(requestCompression),
-					bufferPool:      h.BufferPool,
-					readMaxBytes:    h.ReadMaxBytes,
-				},
-			},
-			responseTrailer: make(http.Header),
+			spec:                    h.Spec,
+			peer:                    peer,
+			request:                 request,
+			requestBody:             requestBody,
+			responseWriter:          responseWriter,
+			responseTrailer:         make(http.Header),
+			codec:                   codec,
+			compressionRequestPool:  h.CompressionPools.Get(requestCompression),
+			compressionResponsePool: h.CompressionPools.Get(responseCompression),
+			bufferPool:              h.BufferPool,
+			compressMinBytes:        h.CompressMinBytes,
+			sendMaxBytes:            h.SendMaxBytes,
+			readMaxBytes:            h.ReadMaxBytes,
 		}
 	}
 	conn = wrapHandlerConnWithCodedErrors(conn)
@@ -375,66 +356,40 @@ func (c *connectClient) NewConn(
 			duplexCall:       duplexCall,
 			compressionPools: c.CompressionPools,
 			bufferPool:       c.BufferPool,
-			marshaler: connectUnaryRequestMarshaler{
-				connectUnaryMarshaler: connectUnaryMarshaler{
-					writer:           duplexCall,
-					codec:            c.Codec,
-					compressMinBytes: c.CompressMinBytes,
-					compressionName:  c.CompressionName,
-					compressionPool:  c.CompressionPools.Get(c.CompressionName),
-					bufferPool:       c.BufferPool,
-					header:           duplexCall.Header(),
-					sendMaxBytes:     c.SendMaxBytes,
-				},
-			},
-			unmarshaler: connectUnaryUnmarshaler{
-				reader:       duplexCall,
-				codec:        c.Codec,
-				bufferPool:   c.BufferPool,
-				readMaxBytes: c.ReadMaxBytes,
-			},
-			responseHeader:  make(http.Header),
-			responseTrailer: make(http.Header),
+			responseHeader:   make(http.Header),
+			responseTrailer:  make(http.Header),
+			compressMinBytes: c.CompressMinBytes,
+			compressionName:  c.CompressionName,
+			compressionPool:  c.CompressionPools.Get(c.CompressionName),
+			codec:            c.Codec,
+			readMaxBytes:     c.ReadMaxBytes,
+			sendMaxBytes:     c.SendMaxBytes,
 		}
 		if spec.IdempotencyLevel == IdempotencyNoSideEffects {
-			unaryConn.marshaler.enableGet = c.EnableGet
-			unaryConn.marshaler.getURLMaxBytes = c.GetURLMaxBytes
-			unaryConn.marshaler.getUseFallback = c.GetUseFallback
-			unaryConn.marshaler.duplexCall = duplexCall
+			unaryConn.enableGet = c.EnableGet
+			unaryConn.getURLMaxBytes = c.GetURLMaxBytes
+			unaryConn.getUseFallback = c.GetUseFallback
+			unaryConn.duplexCall = duplexCall
 			if stableCodec, ok := c.Codec.(stableCodec); ok {
-				unaryConn.marshaler.stableCodec = stableCodec
+				unaryConn.stableCodec = stableCodec
 			}
 		}
 		conn = unaryConn
 		duplexCall.SetValidateResponse(unaryConn.validateResponse)
 	} else {
 		streamingConn := &connectStreamingClientConn{
-			spec:             spec,
-			peer:             c.Peer(),
-			duplexCall:       duplexCall,
-			compressionPools: c.CompressionPools,
-			bufferPool:       c.BufferPool,
-			codec:            c.Codec,
-			marshaler: connectStreamingMarshaler{
-				envelopeWriter: envelopeWriter{
-					writer:           duplexCall,
-					codec:            c.Codec,
-					compressMinBytes: c.CompressMinBytes,
-					compressionPool:  c.CompressionPools.Get(c.CompressionName),
-					bufferPool:       c.BufferPool,
-					sendMaxBytes:     c.SendMaxBytes,
-				},
-			},
-			unmarshaler: connectStreamingUnmarshaler{
-				envelopeReader: envelopeReader{
-					reader:       duplexCall,
-					codec:        c.Codec,
-					bufferPool:   c.BufferPool,
-					readMaxBytes: c.ReadMaxBytes,
-				},
-			},
-			responseHeader:  make(http.Header),
-			responseTrailer: make(http.Header),
+			spec:                   spec,
+			peer:                   c.Peer(),
+			duplexCall:             duplexCall,
+			compressionPools:       c.CompressionPools,
+			compressionRequestPool: c.CompressionPools.Get(c.CompressionName),
+			bufferPool:             c.BufferPool,
+			codec:                  c.Codec,
+			responseHeader:         make(http.Header),
+			responseTrailer:        make(http.Header),
+			compressMinBytes:       c.CompressMinBytes,
+			sendMaxBytes:           c.SendMaxBytes,
+			readMaxBytes:           c.ReadMaxBytes,
 		}
 		conn = streamingConn
 		duplexCall.SetValidateResponse(streamingConn.validateResponse)
@@ -447,11 +402,23 @@ type connectUnaryClientConn struct {
 	peer             Peer
 	duplexCall       *duplexHTTPCall
 	compressionPools readOnlyCompressionPools
+	compressionPool  *compressionPool // set by validateResponse
 	bufferPool       *bufferPool
-	marshaler        connectUnaryRequestMarshaler
-	unmarshaler      connectUnaryUnmarshaler
 	responseHeader   http.Header
 	responseTrailer  http.Header
+
+	codec            Codec
+	compressMinBytes int
+	compressionName  string
+	readMaxBytes     int
+	sendMaxBytes     int
+	alreadyRead      bool
+
+	// Get-related fields
+	enableGet      bool
+	getURLMaxBytes int
+	getUseFallback bool
+	stableCodec    stableCodec
 }
 
 func (cc *connectUnaryClientConn) Spec() Spec {
@@ -463,7 +430,16 @@ func (cc *connectUnaryClientConn) Peer() Peer {
 }
 
 func (cc *connectUnaryClientConn) Send(msg any) error {
-	if err := cc.marshaler.Marshal(msg); err != nil {
+	buffer := cc.bufferPool.Get()
+	defer cc.bufferPool.Put(buffer)
+
+	if cc.enableGet {
+		if err := cc.trySendGet(buffer, msg); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := cc.sendMsg(buffer, msg); err != nil {
 		return err
 	}
 	return nil // must be a literal nil: nil *Error is a non-nil error
@@ -478,8 +454,22 @@ func (cc *connectUnaryClientConn) CloseRequest() error {
 }
 
 func (cc *connectUnaryClientConn) Receive(msg any) error {
+	if cc.alreadyRead {
+		return io.EOF
+	}
+	cc.alreadyRead = true
 	cc.duplexCall.BlockUntilResponseReady()
-	if err := cc.unmarshaler.Unmarshal(msg); err != nil {
+	buffer := cc.bufferPool.Get()
+	defer cc.bufferPool.Put(buffer)
+	if err := readAll(buffer, cc.duplexCall, cc.readMaxBytes); err != nil {
+		return err
+	}
+	if cc.compressionPool != nil {
+		if err := decompress(buffer, cc.bufferPool, cc.compressionPool, cc.readMaxBytes); err != nil {
+			return err
+		}
+	}
+	if err := unmarshal(buffer, msg, cc.codec); err != nil {
 		return err
 	}
 	return nil // must be a literal nil: nil *Error is a non-nil error
@@ -522,47 +512,56 @@ func (cc *connectUnaryClientConn) validateResponse(response *http.Response) *Err
 			cc.compressionPools.CommaSeparatedNames(),
 		)
 	}
+
+	cc.compressionPool = cc.compressionPools.Get(compression)
+	if response.StatusCode == http.StatusOK {
+		return nil
+	}
 	if response.StatusCode == http.StatusNotModified && cc.Spec().IdempotencyLevel == IdempotencyNoSideEffects {
 		serverErr := NewWireError(CodeUnknown, errNotModifiedClient)
 		// RFC 9110 doesn't allow trailers on 304s, so we only need to include headers.
 		serverErr.meta = cc.responseHeader.Clone()
 		return serverErr
-	} else if response.StatusCode != http.StatusOK {
-		unmarshaler := connectUnaryUnmarshaler{
-			reader:          response.Body,
-			compressionPool: cc.compressionPools.Get(compression),
-			bufferPool:      cc.bufferPool,
-		}
-		var wireErr connectWireError
-		if err := unmarshaler.UnmarshalFunc(&wireErr, json.Unmarshal); err != nil {
-			return NewError(
-				connectHTTPToCode(response.StatusCode),
-				errors.New(response.Status),
-			)
-		}
-		serverErr := wireErr.asError()
-		if serverErr == nil {
-			return nil
-		}
-		serverErr.meta = cc.responseHeader.Clone()
-		mergeHeaders(serverErr.meta, cc.responseTrailer)
-		return serverErr
 	}
-	cc.unmarshaler.compressionPool = cc.compressionPools.Get(compression)
-	return nil
+	data := cc.bufferPool.Get()
+	defer cc.bufferPool.Put(data)
+
+	if err := readAll(data, response.Body, cc.readMaxBytes); err != nil {
+		return err
+	}
+	if cc.compressionPool != nil {
+		if err := decompress(data, cc.bufferPool, cc.compressionPool, cc.readMaxBytes); err != nil {
+			return err
+		}
+	}
+	var wireErr connectWireError
+	if err := json.Unmarshal(data.Bytes(), &wireErr); err != nil {
+		return errorf(CodeInternal, "failed to unmarshal error: %v", err)
+	}
+
+	serverErr := wireErr.asError()
+	if serverErr == nil {
+		return nil
+	}
+	serverErr.meta = cc.responseHeader.Clone()
+	mergeHeaders(serverErr.meta, cc.responseTrailer)
+	return serverErr
 }
 
 type connectStreamingClientConn struct {
-	spec             Spec
-	peer             Peer
-	duplexCall       *duplexHTTPCall
-	compressionPools readOnlyCompressionPools
-	bufferPool       *bufferPool
-	codec            Codec
-	marshaler        connectStreamingMarshaler
-	unmarshaler      connectStreamingUnmarshaler
-	responseHeader   http.Header
-	responseTrailer  http.Header
+	spec                    Spec
+	peer                    Peer
+	duplexCall              *duplexHTTPCall
+	compressionPools        readOnlyCompressionPools
+	codec                   Codec
+	responseHeader          http.Header
+	responseTrailer         http.Header
+	compressionRequestPool  *compressionPool
+	compressionResponsePool *compressionPool
+	bufferPool              *bufferPool
+	compressMinBytes        int
+	sendMaxBytes            int
+	readMaxBytes            int
 }
 
 func (cc *connectStreamingClientConn) Spec() Spec {
@@ -574,10 +573,26 @@ func (cc *connectStreamingClientConn) Peer() Peer {
 }
 
 func (cc *connectStreamingClientConn) Send(msg any) error {
-	if err := cc.marshaler.Marshal(msg); err != nil {
+	buffer := cc.bufferPool.Get()
+	defer cc.bufferPool.Put(buffer)
+
+	if err := marshal(buffer, msg, cc.codec); err != nil {
 		return err
 	}
-	return nil // must be a literal nil: nil *Error is a non-nil error
+	var flags uint8
+	if cc.compressionRequestPool != nil && buffer.Len() > cc.compressMinBytes {
+		if err := compress(buffer, cc.bufferPool, cc.compressionRequestPool); err != nil {
+			return err
+		}
+		flags |= flagEnvelopeCompressed
+	}
+	if err := checkSendMaxBytes(buffer, cc.sendMaxBytes, flags&flagEnvelopeCompressed > 0); err != nil {
+		return err
+	}
+	if err := writeEnvelope(cc.duplexCall, flags, buffer); err != nil {
+		return err
+	}
+	return nil // must be a literal nil: nil *error is a non-nil error
 }
 
 func (cc *connectStreamingClientConn) RequestHeader() http.Header {
@@ -590,33 +605,58 @@ func (cc *connectStreamingClientConn) CloseRequest() error {
 
 func (cc *connectStreamingClientConn) Receive(msg any) error {
 	cc.duplexCall.BlockUntilResponseReady()
-	err := cc.unmarshaler.Unmarshal(msg)
-	if err == nil {
-		return nil
+	buffer := cc.bufferPool.Get()
+	defer cc.bufferPool.Put(buffer)
+
+	flags, err := readEnvelope(buffer, cc.duplexCall, cc.readMaxBytes)
+	if err != nil {
+		// If the error is EOF but not from a last message, we want to return
+		// io.ErrUnexpectedEOF instead.
+		if errors.Is(err, io.EOF) {
+			err = errorf(CodeInternal, "protocol error: %w", io.ErrUnexpectedEOF)
+		}
+		return err
 	}
-	// See if the server sent an explicit error in the end-of-stream message.
-	mergeHeaders(cc.responseTrailer, cc.unmarshaler.Trailer())
-	if serverErr := cc.unmarshaler.EndStreamError(); serverErr != nil {
-		// This is expected from a protocol perspective, but receiving an
-		// end-of-stream message means that we're _not_ getting a regular message.
-		// For users to realize that the stream has ended, Receive must return an
-		// error.
-		serverErr.meta = cc.responseHeader.Clone()
-		mergeHeaders(serverErr.meta, cc.responseTrailer)
-		cc.duplexCall.SetError(serverErr)
-		return serverErr
+	if flags&flagEnvelopeCompressed != 0 {
+		if cc.compressionResponsePool == nil {
+			return errorf(CodeInvalidArgument,
+				"protocol error: received compressed message without %s header",
+				connectStreamingHeaderCompression,
+			)
+		}
+		if err := decompress(buffer, cc.bufferPool, cc.compressionResponsePool, cc.readMaxBytes); err != nil {
+			return err
+		}
 	}
-	// If the error is EOF but not from a last message, we want to return
-	// io.ErrUnexpectedEOF instead.
-	if errors.Is(err, io.EOF) && !errors.Is(err, errSpecialEnvelope) {
-		err = errorf(CodeInternal, "protocol error: %w", io.ErrUnexpectedEOF)
+	if flags != 0 && flags != flagEnvelopeCompressed {
+		end, err := connectUnmarshalEndStreamMessage(buffer, flags)
+		if err != nil {
+			return err
+		}
+		// See if the server sent an explicit error in the end-of-stream message.
+		mergeHeaders(cc.responseTrailer, end.Trailer)
+		if serverErr := end.Error.asError(); serverErr != nil {
+			// This is expected from a protocol perspective, but receiving an
+			// end-of-stream message means that we're _not_ getting a regular message.
+			// For users to realize that the stream has ended, Receive must return an
+			// error.
+			serverErr.meta = cc.responseHeader.Clone()
+			mergeHeaders(serverErr.meta, cc.responseTrailer)
+			cc.duplexCall.SetError(serverErr)
+			return serverErr
+		}
+		return io.EOF
 	}
-	// There's no error in the trailers, so this was probably an error
-	// converting the bytes to a message, an error reading from the network, or
-	// just an EOF. We're going to return it to the user, but we also want to
-	// setResponseError so Send errors out.
-	cc.duplexCall.SetError(err)
-	return err
+
+	if err := unmarshal(buffer, msg, cc.codec); err != nil {
+		// There's no error in the trailers, so this was probably an error
+		// converting the bytes to a message, an error reading from the network, or
+		// just an EOF. We're going to return it to the user, but we also want to
+		// setResponseError so Send errors out.
+		cc.duplexCall.SetError(err)
+		return err
+	}
+	return nil // must be a literal nil: nil *Error is a non-nil error
 }
 
 func (cc *connectStreamingClientConn) ResponseHeader() http.Header {
@@ -652,20 +692,29 @@ func (cc *connectStreamingClientConn) validateResponse(response *http.Response) 
 			cc.compressionPools.CommaSeparatedNames(),
 		)
 	}
-	cc.unmarshaler.compressionPool = cc.compressionPools.Get(compression)
+	cc.compressionResponsePool = cc.compressionPools.Get(compression)
 	mergeHeaders(cc.responseHeader, response.Header)
 	return nil
 }
 
 type connectUnaryHandlerConn struct {
-	spec            Spec
-	peer            Peer
-	request         *http.Request
-	responseWriter  http.ResponseWriter
-	marshaler       connectUnaryMarshaler
-	unmarshaler     connectUnaryUnmarshaler
-	responseTrailer http.Header
-	wroteBody       bool
+	spec                    Spec
+	peer                    Peer
+	request                 *http.Request
+	requestBody             io.ReadCloser
+	responseWriter          http.ResponseWriter
+	responseTrailer         http.Header
+	codec                   Codec
+	compressMinBytes        int
+	compressionRequestName  string
+	compressionRequestPool  *compressionPool
+	compressionResponseName string
+	compressionResponsePool *compressionPool
+	bufferPool              *bufferPool
+	sendMaxBytes            int
+	readMaxBytes            int
+	alreadyRead             bool
+	wroteBody               bool
 }
 
 func (hc *connectUnaryHandlerConn) Spec() Spec {
@@ -677,7 +726,23 @@ func (hc *connectUnaryHandlerConn) Peer() Peer {
 }
 
 func (hc *connectUnaryHandlerConn) Receive(msg any) error {
-	if err := hc.unmarshaler.Unmarshal(msg); err != nil {
+	if hc.alreadyRead {
+		return NewError(CodeInternal, io.EOF)
+	}
+	hc.alreadyRead = true
+
+	buffer := hc.bufferPool.Get()
+	defer hc.bufferPool.Put(buffer)
+
+	if err := readAll(buffer, hc.requestBody, hc.readMaxBytes); err != nil {
+		return err
+	}
+	if buffer.Len() > 0 && hc.compressionRequestPool != nil {
+		if err := decompress(buffer, hc.bufferPool, hc.compressionRequestPool, hc.readMaxBytes); err != nil {
+			return err
+		}
+	}
+	if err := unmarshal(buffer, msg, hc.codec); err != nil {
 		return err
 	}
 	return nil // must be a literal nil: nil *Error is a non-nil error
@@ -688,9 +753,29 @@ func (hc *connectUnaryHandlerConn) RequestHeader() http.Header {
 }
 
 func (hc *connectUnaryHandlerConn) Send(msg any) error {
+	buffer := hc.bufferPool.Get()
+	defer hc.bufferPool.Put(buffer)
+
 	hc.wroteBody = true
 	hc.writeResponseHeader(nil /* error */)
-	if err := hc.marshaler.Marshal(msg); err != nil {
+	header := hc.responseWriter.Header()
+
+	if err := marshal(buffer, msg, hc.codec); err != nil {
+		return err
+	}
+	var isCompressed bool
+	if buffer.Len() > hc.compressMinBytes && hc.compressionResponsePool != nil {
+		if err := compress(buffer, hc.bufferPool, hc.compressionResponsePool); err != nil {
+			return err
+		}
+		setHeaderCanonical(header, connectUnaryHeaderCompression, hc.compressionResponseName)
+		isCompressed = true
+	}
+	if err := checkSendMaxBytes(buffer, hc.sendMaxBytes, isCompressed); err != nil {
+		delHeaderCanonical(header, connectUnaryHeaderCompression)
+		return err
+	}
+	if err := writeAll(hc.responseWriter, buffer); err != nil {
 		return err
 	}
 	return nil // must be a literal nil: nil *Error is a non-nil error
@@ -755,13 +840,20 @@ func (hc *connectUnaryHandlerConn) writeResponseHeader(err error) {
 }
 
 type connectStreamingHandlerConn struct {
-	spec            Spec
-	peer            Peer
-	request         *http.Request
-	responseWriter  http.ResponseWriter
-	marshaler       connectStreamingMarshaler
-	unmarshaler     connectStreamingUnmarshaler
-	responseTrailer http.Header
+	spec                    Spec
+	peer                    Peer
+	request                 *http.Request
+	requestBody             io.ReadCloser
+	responseWriter          http.ResponseWriter
+	responseTrailer         http.Header
+	codec                   Codec
+	compressionRequestPool  *compressionPool
+	compressionResponsePool *compressionPool
+	bufferPool              *bufferPool
+	compressMinBytes        int
+	sendMaxBytes            int
+	readMaxBytes            int
+	end                     *connectEndStreamMessage
 }
 
 func (hc *connectStreamingHandlerConn) Spec() Spec {
@@ -773,12 +865,36 @@ func (hc *connectStreamingHandlerConn) Peer() Peer {
 }
 
 func (hc *connectStreamingHandlerConn) Receive(msg any) error {
-	if err := hc.unmarshaler.Unmarshal(msg); err != nil {
-		// Clients may not send end-of-stream metadata, so we don't need to handle
-		// errSpecialEnvelope.
+	buffer := hc.bufferPool.Get()
+	defer hc.bufferPool.Put(buffer)
+
+	flags, err := readEnvelope(buffer, hc.request.Body, hc.readMaxBytes)
+	if err != nil {
 		return err
 	}
-	return nil // must be a literal nil: nil *Error is a non-nil error
+	if flags&flagEnvelopeCompressed != 0 {
+		if hc.compressionRequestPool == nil {
+			return errorf(CodeInvalidArgument,
+				"protocol error: received compressed message without %s header",
+				connectStreamingHeaderCompression,
+			)
+		}
+		if err := decompress(buffer, hc.bufferPool, hc.compressionRequestPool, hc.readMaxBytes); err != nil {
+			return err
+		}
+	}
+	if flags != 0 && flags != flagEnvelopeCompressed {
+		end, err := connectUnmarshalEndStreamMessage(buffer, flags)
+		if err != nil {
+			return err
+		}
+		hc.end = end
+		return io.EOF
+	}
+	if err := unmarshal(buffer, msg, hc.codec); err != nil {
+		return err
+	}
+	return nil // must be a literal nil: nil *error is a non-nil error
 }
 
 func (hc *connectStreamingHandlerConn) RequestHeader() http.Header {
@@ -786,11 +902,31 @@ func (hc *connectStreamingHandlerConn) RequestHeader() http.Header {
 }
 
 func (hc *connectStreamingHandlerConn) Send(msg any) error {
-	defer flushResponseWriter(hc.responseWriter)
-	if err := hc.marshaler.Marshal(msg); err != nil {
+	if msg == nil {
+		hc.responseWriter.WriteHeader(http.StatusOK)
+		return nil
+	}
+	buffer := hc.bufferPool.Get()
+	defer hc.bufferPool.Put(buffer)
+
+	if err := marshal(buffer, msg, hc.codec); err != nil {
 		return err
 	}
-	return nil // must be a literal nil: nil *Error is a non-nil error
+	var flags uint8
+	if buffer.Len() > hc.compressMinBytes && hc.compressionResponsePool != nil {
+		if err := compress(buffer, hc.bufferPool, hc.compressionResponsePool); err != nil {
+			return err
+		}
+		flags |= flagEnvelopeCompressed
+	}
+	if err := checkSendMaxBytes(buffer, hc.sendMaxBytes, flags&flagEnvelopeCompressed > 0); err != nil {
+		return err
+	}
+	if err := writeEnvelope(hc.responseWriter, flags, buffer); err != nil {
+		return err
+	}
+	flushResponseWriter(hc.responseWriter)
+	return nil // must be a literal nil: nil *error is a non-nil error
 }
 
 func (hc *connectStreamingHandlerConn) ResponseHeader() http.Header {
@@ -803,7 +939,8 @@ func (hc *connectStreamingHandlerConn) ResponseTrailer() http.Header {
 
 func (hc *connectStreamingHandlerConn) Close(err error) error {
 	defer flushResponseWriter(hc.responseWriter)
-	if err := hc.marshaler.MarshalEndStream(err, hc.responseTrailer); err != nil {
+
+	if err := hc.marshalEndStream(err, hc.responseTrailer); err != nil {
 		_ = hc.request.Body.Close()
 		return err
 	}
@@ -822,282 +959,119 @@ func (hc *connectStreamingHandlerConn) Close(err error) error {
 	return nil // must be a literal nil: nil *Error is a non-nil error
 }
 
-type connectStreamingMarshaler struct {
-	envelopeWriter
-}
+func (hc *connectStreamingHandlerConn) marshalEndStream(err error, trailer http.Header) *Error {
+	buffer := hc.bufferPool.Get()
+	defer hc.bufferPool.Put(buffer)
 
-func (m *connectStreamingMarshaler) MarshalEndStream(err error, trailer http.Header) *Error {
-	end := &connectEndStreamMessage{Trailer: trailer}
-	if err != nil {
-		end.Error = newConnectWireError(err)
-		if connectErr, ok := asError(err); ok {
-			mergeHeaders(end.Trailer, connectErr.meta)
-		}
-	}
-	data, marshalErr := json.Marshal(end)
-	if marshalErr != nil {
-		return errorf(CodeInternal, "marshal end stream: %w", marshalErr)
-	}
-	raw := bytes.NewBuffer(data)
-	defer m.envelopeWriter.bufferPool.Put(raw)
-	return m.Write(&envelope{
-		Data:  raw,
-		Flags: connectFlagEnvelopeEndStream,
-	})
-}
-
-type connectStreamingUnmarshaler struct {
-	envelopeReader
-
-	endStreamErr *Error
-	trailer      http.Header
-}
-
-func (u *connectStreamingUnmarshaler) Unmarshal(message any) *Error {
-	err := u.envelopeReader.Unmarshal(message)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, errSpecialEnvelope) {
+	end := newConnectEndStreamMessage(err, trailer)
+	if err := connectMarshalEndStreamMessage(buffer, end); err != nil {
 		return err
 	}
-	env := u.envelopeReader.last
-	if !env.IsSet(connectFlagEnvelopeEndStream) {
-		return errorf(CodeInternal, "protocol error: invalid envelope flags %d", env.Flags)
-	}
-	var end connectEndStreamMessage
-	if err := json.Unmarshal(env.Data.Bytes(), &end); err != nil {
-		return errorf(CodeInternal, "unmarshal end stream message: %w", err)
-	}
-	for name, value := range end.Trailer {
-		canonical := http.CanonicalHeaderKey(name)
-		if name != canonical {
-			delete(end.Trailer, name)
-			end.Trailer[canonical] = append(end.Trailer[canonical], value...)
-		}
-	}
-	u.trailer = end.Trailer
-	u.endStreamErr = end.Error.asError()
-	return errSpecialEnvelope
+	return writeEnvelope(hc.responseWriter, connectFlagEnvelopeEndStream, buffer)
 }
 
-func (u *connectStreamingUnmarshaler) Trailer() http.Header {
-	return u.trailer
-}
-
-func (u *connectStreamingUnmarshaler) EndStreamError() *Error {
-	return u.endStreamErr
-}
-
-type connectUnaryMarshaler struct {
-	writer           io.Writer
-	codec            Codec
-	compressMinBytes int
-	compressionName  string
-	compressionPool  *compressionPool
-	bufferPool       *bufferPool
-	header           http.Header
-	sendMaxBytes     int
-}
-
-func (m *connectUnaryMarshaler) Marshal(message any) *Error {
-	if message == nil {
-		return m.write(nil)
-	}
-	data, err := m.codec.Marshal(message)
-	if err != nil {
-		return errorf(CodeInternal, "marshal message: %w", err)
-	}
-	// Can't avoid allocating the slice, but we can reuse it.
-	uncompressed := bytes.NewBuffer(data)
-	defer m.bufferPool.Put(uncompressed)
-	if len(data) < m.compressMinBytes || m.compressionPool == nil {
-		if m.sendMaxBytes > 0 && len(data) > m.sendMaxBytes {
-			return NewError(CodeResourceExhausted, fmt.Errorf("message size %d exceeds sendMaxBytes %d", len(data), m.sendMaxBytes))
-		}
-		return m.write(data)
-	}
-	compressed := m.bufferPool.Get()
-	defer m.bufferPool.Put(compressed)
-	if err := m.compressionPool.Compress(compressed, uncompressed); err != nil {
+func (cc *connectUnaryClientConn) sendMsg(buffer *bytes.Buffer, msg any) error {
+	if err := marshal(buffer, msg, cc.codec); err != nil {
 		return err
 	}
-	if m.sendMaxBytes > 0 && compressed.Len() > m.sendMaxBytes {
-		return NewError(CodeResourceExhausted, fmt.Errorf("compressed message size %d exceeds sendMaxBytes %d", compressed.Len(), m.sendMaxBytes))
-	}
-	setHeaderCanonical(m.header, connectUnaryHeaderCompression, m.compressionName)
-	return m.write(compressed.Bytes())
-}
-
-func (m *connectUnaryMarshaler) write(data []byte) *Error {
-	if _, err := m.writer.Write(data); err != nil {
-		if connectErr, ok := asError(err); ok {
-			return connectErr
+	var isCompressed bool
+	if cc.compressionPool != nil && buffer.Len() > cc.compressMinBytes {
+		if err := compress(buffer, cc.bufferPool, cc.compressionPool); err != nil {
+			return err
 		}
-		return errorf(CodeUnknown, "write message: %w", err)
+		header := cc.duplexCall.Header()
+		setHeaderCanonical(header, connectUnaryHeaderCompression, cc.compressionName)
+		isCompressed = true
+	}
+	if err := checkSendMaxBytes(buffer, cc.sendMaxBytes, isCompressed); err != nil {
+		return err
+	}
+	if err := writeAll(cc.duplexCall, buffer); err != nil {
+		return err
 	}
 	return nil
 }
 
-type connectUnaryRequestMarshaler struct {
-	connectUnaryMarshaler
-
-	enableGet      bool
-	getURLMaxBytes int
-	getUseFallback bool
-	stableCodec    stableCodec
-	duplexCall     *duplexHTTPCall
-}
-
-func (m *connectUnaryRequestMarshaler) Marshal(message any) *Error {
-	if m.enableGet {
-		if m.stableCodec == nil && !m.getUseFallback {
-			return errorf(CodeInternal, "codec %s doesn't support stable marshal; can't use get", m.codec.Name())
+func (cc *connectUnaryClientConn) trySendGet(buffer *bytes.Buffer, msg any) error {
+	if cc.stableCodec == nil {
+		if cc.getUseFallback {
+			return cc.sendMsg(buffer, msg)
 		}
-		if m.stableCodec != nil {
-			return m.marshalWithGet(message)
-		}
+		return errorf(CodeInternal, "codec %s doesn't support stable marshal; can't use get", cc.codec.Name())
 	}
-	return m.connectUnaryMarshaler.Marshal(message)
-}
-
-func (m *connectUnaryRequestMarshaler) marshalWithGet(message any) *Error {
-	// TODO(jchadwick-buf): This function is mostly a superset of
-	// connectUnaryMarshaler.Marshal. This should be reconciled at some point.
-	var data []byte
-	var err error
-	if message != nil {
-		data, err = m.stableCodec.MarshalStable(message)
+	if msg != nil {
+		data, err := cc.stableCodec.MarshalStable(msg)
 		if err != nil {
-			return errorf(CodeInternal, "marshal message stable: %w", err)
+			return err
 		}
+		setBuffer(buffer, data)
 	}
-	isTooBig := m.sendMaxBytes > 0 && len(data) > m.sendMaxBytes
-	if isTooBig && m.compressionPool == nil {
-		return NewError(CodeResourceExhausted, fmt.Errorf(
+
+	isTooBig := cc.sendMaxBytes > 0 && buffer.Len() > cc.sendMaxBytes
+	isCompressed := false
+
+	if isTooBig && cc.compressionPool != nil {
+		if err := compress(buffer, cc.bufferPool, cc.compressionPool); err != nil {
+			return err
+		}
+		isCompressed = true
+		isTooBig = cc.sendMaxBytes > 0 && buffer.Len() > cc.sendMaxBytes
+	}
+
+	if isTooBig {
+		if cc.getUseFallback {
+			buffer.Reset()
+			return cc.sendMsg(buffer, msg)
+		}
+		if isCompressed {
+			return errorf(CodeResourceExhausted,
+				"message size %d exceeds sendMaxBytes %d",
+				buffer.Len(),
+				cc.sendMaxBytes,
+			)
+		}
+		return errorf(CodeResourceExhausted,
 			"message size %d exceeds sendMaxBytes %d: enabling request compression may help",
-			len(data),
-			m.sendMaxBytes,
-		))
+			buffer.Len(),
+			cc.sendMaxBytes,
+		)
 	}
-	if !isTooBig {
-		url := m.buildGetURL(data, false /* compressed */)
-		if m.getURLMaxBytes <= 0 || len(url.String()) < m.getURLMaxBytes {
-			return m.writeWithGet(url)
+
+	header := cc.duplexCall.Header()
+	url := cc.buildGetURL(buffer.Bytes(), isCompressed)
+	if cc.getURLMaxBytes > 0 && len(url.String()) > cc.getURLMaxBytes {
+		if cc.getUseFallback {
+			buffer.Reset()
+			setHeaderCanonical(header, connectUnaryHeaderCompression, cc.compressionName)
+			return cc.sendMsg(buffer, msg)
 		}
-		if m.compressionPool == nil {
-			if m.getUseFallback {
-				return m.write(data)
-			}
-			return NewError(CodeResourceExhausted, fmt.Errorf(
-				"url size %d exceeds getURLMaxBytes %d: enabling request compression may help",
-				len(url.String()),
-				m.getURLMaxBytes,
-			))
-		}
+		return errorf(CodeResourceExhausted,
+			"compressed url size %d exceeds getURLMaxBytes %d",
+			len(url.String()), cc.getURLMaxBytes)
 	}
-	// Compress message to try to make it fit in the URL.
-	uncompressed := bytes.NewBuffer(data)
-	defer m.bufferPool.Put(uncompressed)
-	compressed := m.bufferPool.Get()
-	defer m.bufferPool.Put(compressed)
-	if err := m.compressionPool.Compress(compressed, uncompressed); err != nil {
-		return err
-	}
-	if m.sendMaxBytes > 0 && compressed.Len() > m.sendMaxBytes {
-		return NewError(CodeResourceExhausted, fmt.Errorf("compressed message size %d exceeds sendMaxBytes %d", compressed.Len(), m.sendMaxBytes))
-	}
-	url := m.buildGetURL(compressed.Bytes(), true /* compressed */)
-	if m.getURLMaxBytes <= 0 || len(url.String()) < m.getURLMaxBytes {
-		return m.writeWithGet(url)
-	}
-	if m.getUseFallback {
-		setHeaderCanonical(m.header, connectUnaryHeaderCompression, m.compressionName)
-		return m.write(compressed.Bytes())
-	}
-	return NewError(CodeResourceExhausted, fmt.Errorf("compressed url size %d exceeds getURLMaxBytes %d", len(url.String()), m.getURLMaxBytes))
+
+	delete(header, connectHeaderProtocolVersion)
+	cc.duplexCall.SetMethod(http.MethodGet)
+	*cc.duplexCall.URL() = *url
+	return nil
 }
 
-func (m *connectUnaryRequestMarshaler) buildGetURL(data []byte, compressed bool) *url.URL {
-	url := *m.duplexCall.URL()
+func (cc *connectUnaryClientConn) buildGetURL(data []byte, compressed bool) *url.URL {
+	url := *cc.duplexCall.URL()
 	query := url.Query()
 	query.Set(connectUnaryConnectQueryParameter, connectUnaryConnectQueryValue)
-	query.Set(connectUnaryEncodingQueryParameter, m.codec.Name())
-	if m.stableCodec.IsBinary() || compressed {
+	query.Set(connectUnaryEncodingQueryParameter, cc.codec.Name())
+	if cc.stableCodec.IsBinary() || compressed {
 		query.Set(connectUnaryMessageQueryParameter, encodeBinaryQueryValue(data))
 		query.Set(connectUnaryBase64QueryParameter, "1")
 	} else {
 		query.Set(connectUnaryMessageQueryParameter, string(data))
 	}
 	if compressed {
-		query.Set(connectUnaryCompressionQueryParameter, m.compressionName)
+		query.Set(connectUnaryCompressionQueryParameter, cc.compressionName)
 	}
 	url.RawQuery = query.Encode()
 	return &url
-}
-
-func (m *connectUnaryRequestMarshaler) writeWithGet(url *url.URL) *Error {
-	delete(m.header, connectHeaderProtocolVersion)
-	m.duplexCall.SetMethod(http.MethodGet)
-	*m.duplexCall.URL() = *url
-	return nil
-}
-
-type connectUnaryUnmarshaler struct {
-	reader          io.Reader
-	codec           Codec
-	compressionPool *compressionPool
-	bufferPool      *bufferPool
-	alreadyRead     bool
-	readMaxBytes    int
-}
-
-func (u *connectUnaryUnmarshaler) Unmarshal(message any) *Error {
-	return u.UnmarshalFunc(message, u.codec.Unmarshal)
-}
-
-func (u *connectUnaryUnmarshaler) UnmarshalFunc(message any, unmarshal func([]byte, any) error) *Error {
-	if u.alreadyRead {
-		return NewError(CodeInternal, io.EOF)
-	}
-	u.alreadyRead = true
-	data := u.bufferPool.Get()
-	defer u.bufferPool.Put(data)
-	reader := u.reader
-	if u.readMaxBytes > 0 && int64(u.readMaxBytes) < math.MaxInt64 {
-		reader = io.LimitReader(u.reader, int64(u.readMaxBytes)+1)
-	}
-	// ReadFrom ignores io.EOF, so any error here is real.
-	bytesRead, err := data.ReadFrom(reader)
-	if err != nil {
-		if connectErr, ok := asError(err); ok {
-			return connectErr
-		}
-		if readMaxBytesErr := asMaxBytesError(err, "read first %d bytes of message", bytesRead); readMaxBytesErr != nil {
-			return readMaxBytesErr
-		}
-		return errorf(CodeUnknown, "read message: %w", err)
-	}
-	if u.readMaxBytes > 0 && bytesRead > int64(u.readMaxBytes) {
-		// Attempt to read to end in order to allow connection re-use
-		discardedBytes, err := io.Copy(io.Discard, u.reader)
-		if err != nil {
-			return errorf(CodeResourceExhausted, "message is larger than configured max %d - unable to determine message size: %w", u.readMaxBytes, err)
-		}
-		return errorf(CodeResourceExhausted, "message size %d is larger than configured max %d", bytesRead+discardedBytes, u.readMaxBytes)
-	}
-	if data.Len() > 0 && u.compressionPool != nil {
-		decompressed := u.bufferPool.Get()
-		defer u.bufferPool.Put(decompressed)
-		if err := u.compressionPool.Decompress(decompressed, data, int64(u.readMaxBytes)); err != nil {
-			return err
-		}
-		data = decompressed
-	}
-	if err := unmarshal(data.Bytes(), message); err != nil {
-		return errorf(CodeInvalidArgument, "unmarshal into %T: %w", message, err)
-	}
-	return nil
 }
 
 type connectWireDetail ErrorDetail
@@ -1195,6 +1169,20 @@ func (e *connectWireError) asError() *Error {
 type connectEndStreamMessage struct {
 	Error   *connectWireError `json:"error,omitempty"`
 	Trailer http.Header       `json:"metadata,omitempty"`
+}
+
+func newConnectEndStreamMessage(err error, trailer http.Header) *connectEndStreamMessage {
+	if trailer == nil {
+		trailer = make(http.Header)
+	}
+	end := &connectEndStreamMessage{Trailer: trailer}
+	if err != nil {
+		end.Error = newConnectWireError(err)
+		if connectErr, ok := asError(err); ok {
+			mergeHeaders(end.Trailer, connectErr.meta)
+		}
+	}
+	return end
 }
 
 func connectCodeToHTTP(code Code) int {
@@ -1305,4 +1293,31 @@ func queryValueReader(data string, base64Encoded bool) io.Reader {
 		return binaryQueryValueReader(data)
 	}
 	return strings.NewReader(data)
+}
+
+func connectUnmarshalEndStreamMessage(src *bytes.Buffer, flags uint8) (*connectEndStreamMessage, *Error) {
+	end := connectEndStreamMessage{}
+	if flags^connectFlagEnvelopeEndStream != 0 {
+		return nil, newErrInvalidEnvelopeFlags(flags)
+	}
+	// end of stream...
+	if err := json.Unmarshal(src.Bytes(), &end); err != nil {
+		return nil, errorf(CodeInternal, "unmarshal end stream message: %w", err)
+	}
+	for name, value := range end.Trailer {
+		canonical := http.CanonicalHeaderKey(name)
+		if name != canonical {
+			delete(end.Trailer, name)
+			end.Trailer[canonical] = append(end.Trailer[canonical], value...)
+		}
+	}
+	return &end, nil
+}
+func connectMarshalEndStreamMessage(dst *bytes.Buffer, end *connectEndStreamMessage) *Error {
+	data, marshalErr := json.Marshal(end)
+	if marshalErr != nil {
+		return errorf(CodeInternal, "marshal end stream: %w", marshalErr)
+	}
+	setBuffer(dst, data)
+	return nil
 }

--- a/protocol_connect_test.go
+++ b/protocol_connect_test.go
@@ -60,36 +60,28 @@ func TestConnectErrorDetailMarshalingNoDescriptor(t *testing.T) {
 func TestConnectEndOfResponseCanonicalTrailers(t *testing.T) {
 	t.Parallel()
 
-	buffer := bytes.Buffer{}
-	bufferPool := newBufferPool()
-
-	endStreamMessage := connectEndStreamMessage{Trailer: make(http.Header)}
+	endStreamMessage := newConnectEndStreamMessage(nil, make(http.Header))
 	endStreamMessage.Trailer["not-canonical-header"] = []string{"a"}
 	endStreamMessage.Trailer["mixed-Canonical"] = []string{"b"}
 	endStreamMessage.Trailer["Mixed-Canonical"] = []string{"b"}
 	endStreamMessage.Trailer["Canonical-Header"] = []string{"c"}
-	endStreamData, err := json.Marshal(endStreamMessage)
+
+	data := &bytes.Buffer{}
+	err := connectMarshalEndStreamMessage(data, endStreamMessage)
 	assert.Nil(t, err)
 
-	writer := envelopeWriter{
-		writer:     &buffer,
-		bufferPool: bufferPool,
-	}
-	err = writer.Write(&envelope{
-		Flags: connectFlagEnvelopeEndStream,
-		Data:  bytes.NewBuffer(endStreamData),
-	})
+	output := &bytes.Buffer{}
+	err = writeEnvelope(output, connectFlagEnvelopeEndStream, data)
 	assert.Nil(t, err)
 
-	unmarshaler := connectStreamingUnmarshaler{
-		envelopeReader: envelopeReader{
-			reader:     &buffer,
-			bufferPool: bufferPool,
-		},
-	}
-	err = unmarshaler.Unmarshal(nil) // parameter won't be used
-	assert.ErrorIs(t, err, errSpecialEnvelope)
-	assert.Equal(t, unmarshaler.Trailer().Values("Not-Canonical-Header"), []string{"a"})
-	assert.Equal(t, unmarshaler.Trailer().Values("Mixed-Canonical"), []string{"b", "b"})
-	assert.Equal(t, unmarshaler.Trailer().Values("Canonical-Header"), []string{"c"})
+	input := &bytes.Buffer{}
+	_, err = readEnvelope(input, output, -1)
+	assert.Nil(t, err)
+
+	end, err := connectUnmarshalEndStreamMessage(input, connectFlagEnvelopeEndStream)
+	assert.Nil(t, err)
+
+	assert.Equal(t, end.Trailer.Values("Not-Canonical-Header"), []string{"a"})
+	assert.Equal(t, end.Trailer.Values("Mixed-Canonical"), []string{"b", "b"})
+	assert.Equal(t, end.Trailer.Values("Canonical-Header"), []string{"c"})
 }

--- a/protocol_connect_test.go
+++ b/protocol_connect_test.go
@@ -66,12 +66,14 @@ func TestConnectEndOfResponseCanonicalTrailers(t *testing.T) {
 	endStreamMessage.Trailer["Mixed-Canonical"] = []string{"b"}
 	endStreamMessage.Trailer["Canonical-Header"] = []string{"c"}
 
-	data := &bytes.Buffer{}
-	err := connectMarshalEndStreamMessage(data, endStreamMessage)
+	envelope := makeEnvelope(&bytes.Buffer{})
+	err := connectMarshalEndStreamMessage(envelope.Buffer, endStreamMessage)
 	assert.Nil(t, err)
 
+	envelope.encodeSizeAndFlags(connectFlagEnvelopeEndStream)
+
 	output := &bytes.Buffer{}
-	err = writeEnvelope(output, connectFlagEnvelopeEndStream, data)
+	err = writeAll(output, envelope.Buffer)
 	assert.Nil(t, err)
 
 	input := &bytes.Buffer{}

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -43,16 +43,11 @@ func TestGRPCHandlerSender(t *testing.T) {
 		)
 		assert.Nil(t, err)
 		return &grpcHandlerConn{
-			spec:       Spec{},
-			web:        web,
-			bufferPool: bufferPool,
-			protobuf:   protobufCodec,
-			send: messageParams{
-				codec: protobufCodec,
-			},
-			recv: messageParams{
-				codec: protobufCodec,
-			},
+			spec:            Spec{},
+			web:             web,
+			bufferPool:      bufferPool,
+			protobuf:        protobufCodec,
+			codec:           protobufCodec,
 			responseWriter:  responseWriter,
 			responseHeader:  make(http.Header),
 			responseTrailer: make(http.Header),

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -43,11 +43,16 @@ func TestGRPCHandlerSender(t *testing.T) {
 		)
 		assert.Nil(t, err)
 		return &grpcHandlerConn{
-			spec:            Spec{},
-			web:             web,
-			bufferPool:      bufferPool,
-			protobuf:        protobufCodec,
-			codec:           protobufCodec,
+			spec:       Spec{},
+			web:        web,
+			bufferPool: bufferPool,
+			protobuf:   protobufCodec,
+			send: messageParams{
+				codec: protobufCodec,
+			},
+			recv: messageParams{
+				codec: protobufCodec,
+			},
 			responseWriter:  responseWriter,
 			responseHeader:  make(http.Header),
 			responseTrailer: make(http.Header),


### PR DESCRIPTION
A new API for working with envelope messages. Envelopes are built up within a single buffer. We can now use a single write call and pass a bytes.Buffer as the full payload.

With this change marshallers no longer write to the stream. Control is given to the protocols connection handler. This allows the protocols implementation to easily customize the behaviour. However, it does duplicates some of the flow. Overall I think it's simpler to duplicate control flow into the connection handler to allow for protocol specific features. Changes:
- Connect unary now use `marshal` to gain `marshalAppend` codecs: https://github.com/bufbuild/connect-go/blob/6183cbf6ff174060dbdc494095ed7934dee4bc7d/protocol_connect.go#L907
- No longer need to partially build envelopeWriters, create the envelope and write it instead: https://github.com/bufbuild/connect-go/blob/6183cbf6ff174060dbdc494095ed7934dee4bc7d/error_writer.go#L133-L138
- `errSpecialEnvelope` is no longer needed, protocols check for end flags directly: https://github.com/bufbuild/connect-go/blob/6183cbf6ff174060dbdc494095ed7934dee4bc7d/envelope.go#L28
- gRPC read trailer functions can be moved into the `Receive()` functions: https://github.com/bufbuild/connect-go/blob/6183cbf6ff174060dbdc494095ed7934dee4bc7d/protocol_grpc.go#L323
-  Easier to avoid leaking abstractions from one protocol to the other. Error messages are set in the handler: https://github.com/bufbuild/connect-go/blob/6183cbf6ff174060dbdc494095ed7934dee4bc7d/envelope.go#L190
- Small reduction in allocs/op:
```diff
- BenchmarkConnect/unary-8                     583           2035062 ns/op         5448544 B/op        232 allocs/op
+ BenchmarkConnect/unary-8                     580           2054063 ns/op         5190420 B/op        221 allocs/op
```

